### PR TITLE
Possible fix for crash on module unload

### DIFF
--- a/client/admin_client.lua
+++ b/client/admin_client.lua
@@ -9,17 +9,19 @@ msgColors =
 
 function Admin:__init ( )
 	self.permissions = { }
-	self.panel = { }
-	self.banPanel = { }
-	self.kickPanel = { }
-	self.mutePanel = { }
-	self.warpPanel = { }
-	self.manualBanPanel = { }
-	self.shoutPanel = { }
-	self.permPanelChange = { }
-	self.aclCreatePanel = { }
-	self.aclObjectPanel = { }
-	self.vehColorPanel = { }
+	self.panel = {
+		main = { },
+		ban = { },
+		kick = { },
+		mute = { },
+		warp = { },
+		manualBan = { },
+		shout = { },
+		permChange = { },
+		aclCreate = { },
+		aclObject = { },
+		vehColor = { }
+	}
 	self.players = { }
 	self.warpPlayers = { }
 	self.serverInfo = { }
@@ -63,289 +65,290 @@ function Admin:__init ( )
 	end
 	table.sort ( self.vehicleList, function ( a, b ) return ( a < b ) end )
 
-	self.panel.window = GUI:Window ( "Admin Panel by Castillo v0.2", Vector2 ( 0.2, 0.5 ), Vector2 ( 0.5, 0.8 ) )
-	self.panel.window:Subscribe ( "WindowClosed", self, self.onPanelClose )
-	self.panel.window:SetVisible ( false )
-	GUI:Center ( self.panel.window )
-	self.panel.tabPanel, self.tabs = GUI:TabControl ( { "Players", "ACL", "Bans", "Modules", "Server", "AdminChat" }, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.0, 0.0 ), self.panel.window )
-	self.panel.tabPanel:SetDock ( GwenPosition.Fill )
-	self.panel.playersTab = self.tabs.players.base
-	self.panel.aclTab = self.tabs.acl.base
-	self.panel.bansTab = self.tabs.bans.base
-	self.panel.modulesTab = self.tabs.modules.base
-	self.panel.serverTab = self.tabs.server.base
-	self.panel.adminchatTab = self.tabs.adminchat.base
+	self.panel.main.window = GUI:Window ( "Admin Panel by Castillo v0.2", Vector2 ( 0.2, 0.5 ), Vector2 ( 0.5, 0.8 ) )
+	self.panel.main.window:Subscribe ( "WindowClosed", self, self.onPanelClose )
+	self.panel.main.window:SetVisible ( false )
+	GUI:Center ( self.panel.main.window )
+	self.panel.main.tabPanel, self.tabs = GUI:TabControl ( { "Players", "ACL", "Bans", "Modules", "Server", "AdminChat" }, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.0, 0.0 ), self.panel.main.window )
+	self.panel.main.tabPanel:SetDock ( GwenPosition.Fill )
+	self.panel.main.playersTab = self.tabs.players.base
+	self.panel.main.aclTab = self.tabs.acl.base
+	self.panel.main.bansTab = self.tabs.bans.base
+	self.panel.main.modulesTab = self.tabs.modules.base
+	self.panel.main.serverTab = self.tabs.server.base
+	self.panel.main.adminchatTab = self.tabs.adminchat.base
 
-	self.panel.playersList = GUI:SortedList ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.16, 0.66 ), self.panel.playersTab, { { name = "Players" } } )
-	self.panel.playersList:Subscribe ( "RowSelected", self, self.getInformation )
-	self.panel.playersSearch = GUI:TextBox ( "", Vector2 ( 0.0, 0.67 ), Vector2 ( 0.16, 0.035 ), "text", self.panel.playersTab )
-	self.panel.playersSearch:Subscribe ( "TextChanged", self, self.searchPlayer )
-	GUI:Label ( "Player:", Vector2 ( 0.165, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.playersTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.playerName = GUI:Label ( "Name: N/A", Vector2 ( 0.17, 0.04 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerSteamID = GUI:Label ( "Steam ID: N/A", Vector2 ( 0.17, 0.07 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerIP = GUI:Label ( "IP: N/A", Vector2 ( 0.17, 0.1 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerPing = GUI:Label ( "Ping: N/A", Vector2 ( 0.17, 0.13 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerGroups = GUI:Label ( "Groups: N/A", Vector2 ( 0.17, 0.16 ), Vector2 ( 0.185, 0.03 ), self.panel.playersTab )
-	self.panel.playerGroups:SetWrap ( true )
-	GUI:Label ( "Game:", Vector2 ( 0.165, 0.2 ), Vector2 ( 0.2, 0.1 ), self.panel.playersTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.playerHealth = GUI:Label ( "Health: N/A", Vector2 ( 0.17, 0.23 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerMoney = GUI:Label ( "Money: N/A", Vector2 ( 0.17, 0.26 ), Vector2 ( 0.2, 0.5 ), self.panel.playersTab )
-	self.panel.playerPosition = GUI:Label ( "Position: N/A", Vector2 ( 0.17, 0.29 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerAngle = GUI:Label ( "Angle: N/A", Vector2 ( 0.17, 0.32 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerModel = GUI:Label ( "Model: N/A", Vector2 ( 0.17, 0.35 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerWorld = GUI:Label ( "World: N/A", Vector2 ( 0.17, 0.38 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerWeapon = GUI:Label ( "Weapon: N/A", Vector2 ( 0.17, 0.41 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerWeaponAmmo = GUI:Label ( "Weapon ammo: N/A", Vector2 ( 0.17, 0.44 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	GUI:Label ( "Vehicle:", Vector2 ( 0.165, 0.48 ), Vector2 ( 0.2, 0.1 ), self.panel.playersTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.playerVehicle = GUI:Label ( "Name: N/A", Vector2 ( 0.17, 0.51 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
-	self.panel.playerVehicleHealth = GUI:Label ( "Health: N/A", Vector2 ( 0.17, 0.54 ), Vector2 ( 0.2, 0.03 ), self.panel.playersTab )
+	self.panel.main.playersList = GUI:SortedList ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.16, 0.66 ), self.panel.main.playersTab, { { name = "Players" } } )
+	self.panel.main.playersList:Subscribe ( "RowSelected", self, self.getInformation )
+	self.panel.main.playersSearch = GUI:TextBox ( "", Vector2 ( 0.0, 0.67 ), Vector2 ( 0.16, 0.035 ), "text", self.panel.main.playersTab )
+	self.panel.main.playersSearch:Subscribe ( "TextChanged", self, self.searchPlayer )
+	GUI:Label ( "Player:", Vector2 ( 0.165, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.main.playersTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.playerName = GUI:Label ( "Name: N/A", Vector2 ( 0.17, 0.04 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerSteamID = GUI:Label ( "Steam ID: N/A", Vector2 ( 0.17, 0.07 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerIP = GUI:Label ( "IP: N/A", Vector2 ( 0.17, 0.1 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerPing = GUI:Label ( "Ping: N/A", Vector2 ( 0.17, 0.13 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerGroups = GUI:Label ( "Groups: N/A", Vector2 ( 0.17, 0.16 ), Vector2 ( 0.185, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerGroups:SetWrap ( true )
+	GUI:Label ( "Game:", Vector2 ( 0.165, 0.2 ), Vector2 ( 0.2, 0.1 ), self.panel.main.playersTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.playerHealth = GUI:Label ( "Health: N/A", Vector2 ( 0.17, 0.23 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerMoney = GUI:Label ( "Money: N/A", Vector2 ( 0.17, 0.26 ), Vector2 ( 0.2, 0.5 ), self.panel.main.playersTab )
+	self.panel.main.playerPosition = GUI:Label ( "Position: N/A", Vector2 ( 0.17, 0.29 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerAngle = GUI:Label ( "Angle: N/A", Vector2 ( 0.17, 0.32 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerModel = GUI:Label ( "Model: N/A", Vector2 ( 0.17, 0.35 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerWorld = GUI:Label ( "World: N/A", Vector2 ( 0.17, 0.38 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerWeapon = GUI:Label ( "Weapon: N/A", Vector2 ( 0.17, 0.41 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerWeaponAmmo = GUI:Label ( "Weapon ammo: N/A", Vector2 ( 0.17, 0.44 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	GUI:Label ( "Vehicle:", Vector2 ( 0.165, 0.48 ), Vector2 ( 0.2, 0.1 ), self.panel.main.playersTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.playerVehicle = GUI:Label ( "Name: N/A", Vector2 ( 0.17, 0.51 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
+	self.panel.main.playerVehicleHealth = GUI:Label ( "Health: N/A", Vector2 ( 0.17, 0.54 ), Vector2 ( 0.2, 0.03 ), self.panel.main.playersTab )
 
-	self.panel.ban = GUI:Button ( "Ban", Vector2 ( 0.36, 0.01 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.ban" )
-	self.panel.ban:Subscribe ( "Press", self, self.showBanWindow )
-	self.panel.kick = GUI:Button ( "Kick", Vector2 ( 0.423, 0.01 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.kick" )
-	self.panel.kick:Subscribe ( "Press", self, self.showKickWindow )
-	self.panel.mute = GUI:Button ( "Mute", Vector2 ( 0.36, 0.05 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.mute" )
-	self.panel.mute:Subscribe ( "Press", self, self.showMuteWindow )
-	self.panel.freeze = GUI:Button ( "Freeze", Vector2 ( 0.423, 0.05 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.freeze" )
-	self.panel.freeze:Subscribe ( "Press", self, self.freezePlayer )
-	self.panel.kill = GUI:Button ( "kill", Vector2 ( 0.36, 0.09 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab, "player.kill" )
-	self.panel.kill:Subscribe ( "Press", self, self.killPlayer )
-	self.panel.valueField = GUI:TextBox ( "", Vector2 ( 0.36, 0.15 ), Vector2 ( 0.123, 0.03 ), "numeric", self.panel.playersTab )
-	self.panel.setHealth = GUI:Button ( "Set Health", Vector2 ( 0.36, 0.19 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.sethealth" )
-	self.panel.setHealth:Subscribe ( "Press", self, self.setHealth )
-	self.panel.setModel = GUI:Button ( "Set Model", Vector2 ( 0.423, 0.19 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.setmodel" )
-	self.panel.setModel:Subscribe ( "Press", self, self.setModel )
-	self.panel.setMoney = GUI:Button ( "Set Money", Vector2 ( 0.36, 0.23 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.setmoney" )
-	self.panel.setMoney:Subscribe ( "Press", self, self.setMoney )
-	self.panel.giveMoney = GUI:Button ( "Give money", Vector2 ( 0.423, 0.23 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.givemoney" )
-	self.panel.giveMoney:Subscribe ( "Press", self, self.giveMoney )
-	self.panel.warpTo = GUI:Button ( "Warp to...", Vector2 ( 0.36, 0.28 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.warp" )
-	self.panel.warpTo:Subscribe ( "Press", self, self.warpTo )
-	self.panel.spectate = GUI:Button ( "Spectate", Vector2 ( 0.423, 0.28 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.spectate" )
-	self.panel.spectate:Subscribe ( "Press", self, self.spectate )
-	self.panel.warpPlayerTo = GUI:Button ( "Warp player to...", Vector2 ( 0.36, 0.32 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab, "player.warpto" )
-	self.panel.warpPlayerTo:Subscribe ( "Press", self, self.showWarpWindow )
-	self.panel.vehicleMenu, items = GUI:ComboBox ( Vector2 ( 0.36, 0.36 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab, self.vehicleList )
+	self.panel.main.ban = GUI:Button ( "Ban", Vector2 ( 0.36, 0.01 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.ban" )
+	self.panel.main.ban:Subscribe ( "Press", self, self.showBanWindow )
+	self.panel.main.kick = GUI:Button ( "Kick", Vector2 ( 0.423, 0.01 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.kick" )
+	self.panel.main.kick:Subscribe ( "Press", self, self.showKickWindow )
+	self.panel.main.mute = GUI:Button ( "Mute", Vector2 ( 0.36, 0.05 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.mute" )
+	self.panel.main.mute:Subscribe ( "Press", self, self.showMuteWindow )
+	self.panel.main.freeze = GUI:Button ( "Freeze", Vector2 ( 0.423, 0.05 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.freeze" )
+	self.panel.main.freeze:Subscribe ( "Press", self, self.freezePlayer )
+	self.panel.main.kill = GUI:Button ( "kill", Vector2 ( 0.36, 0.09 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab, "player.kill" )
+	self.panel.main.kill:Subscribe ( "Press", self, self.killPlayer )
+	self.panel.main.valueField = GUI:TextBox ( "", Vector2 ( 0.36, 0.15 ), Vector2 ( 0.123, 0.03 ), "numeric", self.panel.main.playersTab )
+	self.panel.main.setHealth = GUI:Button ( "Set Health", Vector2 ( 0.36, 0.19 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.sethealth" )
+	self.panel.main.setHealth:Subscribe ( "Press", self, self.setHealth )
+	self.panel.main.setModel = GUI:Button ( "Set Model", Vector2 ( 0.423, 0.19 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.setmodel" )
+	self.panel.main.setModel:Subscribe ( "Press", self, self.setModel )
+	self.panel.main.setMoney = GUI:Button ( "Set Money", Vector2 ( 0.36, 0.23 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.setmoney" )
+	self.panel.main.setMoney:Subscribe ( "Press", self, self.setMoney )
+	self.panel.main.giveMoney = GUI:Button ( "Give money", Vector2 ( 0.423, 0.23 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.givemoney" )
+	self.panel.main.giveMoney:Subscribe ( "Press", self, self.giveMoney )
+	self.panel.main.warpTo = GUI:Button ( "Warp to...", Vector2 ( 0.36, 0.28 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.warp" )
+	self.panel.main.warpTo:Subscribe ( "Press", self, self.warpTo )
+	self.panel.main.spectate = GUI:Button ( "Spectate", Vector2 ( 0.423, 0.28 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.spectate" )
+	self.panel.main.spectate:Subscribe ( "Press", self, self.spectate )
+	self.panel.main.warpPlayerTo = GUI:Button ( "Warp player to...", Vector2 ( 0.36, 0.32 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab, "player.warpto" )
+	self.panel.main.warpPlayerTo:Subscribe ( "Press", self, self.showWarpWindow )
+	self.panel.main.vehicleMenu, items = GUI:ComboBox ( Vector2 ( 0.36, 0.36 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab, self.vehicleList )
 	for _, item in pairs ( items ) do
 		item:Subscribe ( "Press", self, self.displayVehicleTemplates )
 	end
 
-	self.panel.vehicleTemplateMenu = GUI:ComboBox ( Vector2 ( 0.36, 0.4 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab )
-	table.insert ( self.templateItems, self.panel.vehicleTemplateMenu:AddItem ( "Default" ) )
-	self.panel.giveVehicle = GUI:Button ( "Give", Vector2 ( 0.36, 0.44 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.givevehicle" )
-	self.panel.giveVehicle:Subscribe ( "Press", self, self.giveVehicle )
-	self.panel.destroyVehicle = GUI:Button ( "Destroy", Vector2 ( 0.423, 0.44 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.destroyvehicle" )
-	self.panel.destroyVehicle:Subscribe ( "Press", self, self.destroyVehicle )
-	self.panel.repairVehicle = GUI:Button ( "Repair", Vector2 ( 0.36, 0.48 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.repairvehicle" )
-	self.panel.repairVehicle:Subscribe ( "Press", self, self.repairVehicle )
-	self.panel.setVehicleColour = GUI:Button ( "Set colour", Vector2 ( 0.423, 0.48 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.setvehiclecolour" )
-	self.panel.setVehicleColour:Subscribe ( "Press", self, self.showVehicleColourSelector )
-	self.panel.weaponMenu = GUI:ComboBox ( Vector2 ( 0.36, 0.53 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab, getWeaponNames ( ) )
-	self.panel.weaponSlotMenu = GUI:ComboBox ( Vector2 ( 0.36, 0.57 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, { "Primary", "Left", "Right" } )
-	self.panel.giveWeapon = GUI:Button ( "Give", Vector2 ( 0.423, 0.57 ), Vector2 ( 0.06, 0.03 ), self.panel.playersTab, "player.giveweapon" )
-	self.panel.giveWeapon:Subscribe ( "Press", self, self.giveWeapon )
-	self.panel.giveAdmin = GUI:Button ( "Give admin rights", Vector2 ( 0.36, 0.67 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab, "player.giveadmin" )
-	self.panel.giveAdmin:Subscribe ( "Press", self, self.giveAdmin )
-	self.panel.shout = GUI:Button ( "Shout", Vector2 ( 0.36, 0.63 ), Vector2 ( 0.123, 0.03 ), self.panel.playersTab, "player.shout" )
-	self.panel.shout:Subscribe ( "Press", self, self.showShoutWindow )
+	self.panel.main.vehicleTemplateMenu = GUI:ComboBox ( Vector2 ( 0.36, 0.4 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab )
+	table.insert ( self.templateItems, self.panel.main.vehicleTemplateMenu:AddItem ( "Default" ) )
+	self.panel.main.giveVehicle = GUI:Button ( "Give", Vector2 ( 0.36, 0.44 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.givevehicle" )
+	self.panel.main.giveVehicle:Subscribe ( "Press", self, self.giveVehicle )
+	self.panel.main.destroyVehicle = GUI:Button ( "Destroy", Vector2 ( 0.423, 0.44 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.destroyvehicle" )
+	self.panel.main.destroyVehicle:Subscribe ( "Press", self, self.destroyVehicle )
+	self.panel.main.repairVehicle = GUI:Button ( "Repair", Vector2 ( 0.36, 0.48 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.repairvehicle" )
+	self.panel.main.repairVehicle:Subscribe ( "Press", self, self.repairVehicle )
+	self.panel.main.setVehicleColour = GUI:Button ( "Set colour", Vector2 ( 0.423, 0.48 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.setvehiclecolour" )
+	self.panel.main.setVehicleColour:Subscribe ( "Press", self, self.showVehicleColourSelector )
+	self.panel.main.weaponMenu = GUI:ComboBox ( Vector2 ( 0.36, 0.53 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab, getWeaponNames ( ) )
+	self.panel.main.weaponSlotMenu = GUI:ComboBox ( Vector2 ( 0.36, 0.57 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, { "Primary", "Left", "Right" } )
+	self.panel.main.giveWeapon = GUI:Button ( "Give", Vector2 ( 0.423, 0.57 ), Vector2 ( 0.06, 0.03 ), self.panel.main.playersTab, "player.giveweapon" )
+	self.panel.main.giveWeapon:Subscribe ( "Press", self, self.giveWeapon )
+	self.panel.main.giveAdmin = GUI:Button ( "Give admin rights", Vector2 ( 0.36, 0.67 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab, "player.giveadmin" )
+	self.panel.main.giveAdmin:Subscribe ( "Press", self, self.giveAdmin )
+	self.panel.main.shout = GUI:Button ( "Shout", Vector2 ( 0.36, 0.63 ), Vector2 ( 0.123, 0.03 ), self.panel.main.playersTab, "player.shout" )
+	self.panel.main.shout:Subscribe ( "Press", self, self.showShoutWindow )
 
-	GUI:Label ( "Server:", Vector2 ( 0.0, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.serverTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.serverName = GUI:Label ( "Server name: N/A", Vector2 ( 0.005, 0.04 ), Vector2 ( 0.0, 0.0 ), self.panel.serverTab )
-	self.panel.serverPlayers = GUI:Label ( "Players online: N/A", Vector2 ( 0.005, 0.07 ), Vector2 ( 0.0, 0.0 ), self.panel.serverTab )
-	self.panel.serverDescription = GUI:Label ( "Description: N/A", Vector2 ( 0.005, 0.1 ), Vector2 ( 0.1, 0.03 ), self.panel.serverTab )
-	self.panel.serverSpawnPosition = GUI:Label ( "Spawn Position: N/A", Vector2 ( 0.005, 0.13 ), Vector2 ( 0.1, 0.03 ), self.panel.serverTab )
-	self.panel.serverTime = GUI:Label ( "Spawn Position: N/A", Vector2 ( 0.005, 0.16 ), Vector2 ( 0.1, 0.03 ), self.panel.serverTab )
-	GUI:Label ( "Game:", Vector2 ( 0.0, 0.19 ), Vector2 ( 0.2, 0.13 ), self.panel.serverTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.serverGameTime = GUI:Label ( "Game Time: N/A", Vector2 ( 0.005, 0.22 ), Vector2 ( 0.0, 0.0 ), self.panel.serverTab )
-	self.panel.serverGameTimeField = GUI:TextBox ( "", Vector2 ( 0.14, 0.219 ), Vector2 ( 0.03, 0.023 ), "numeric", self.panel.serverTab )
-	self.panel.setGameTime = GUI:Button ( "Set", Vector2 ( 0.175, 0.218 ), Vector2 ( 0.031, 0.029 ), self.panel.serverTab, "general.settime" )
-	self.panel.setGameTime:Subscribe ( "Press", self, self.setTime )
-	GUI:Label ( "(0-23)", Vector2 ( 0.21, 0.225 ), Vector2 ( 0.03, 0.03 ), self.panel.serverTab )
-	self.panel.serverWeather = GUI:Label ( "Weather Severity: N/A", Vector2 ( 0.005, 0.25 ), Vector2 ( 0.0, 0.0 ), self.panel.serverTab )
-	self.panel.serverWeatherField = GUI:TextBox ( "", Vector2 ( 0.14, 0.25 ), Vector2 ( 0.03, 0.023 ), "numeric", self.panel.serverTab )
-	self.panel.setWeatherSeverity = GUI:Button ( "Set", Vector2 ( 0.175, 0.25 ), Vector2 ( 0.031, 0.029 ), self.panel.serverTab, "general.setweather" )
-	self.panel.setWeatherSeverity:Subscribe ( "Press", self, self.setWeather )
-	GUI:Label ( "(0-2)", Vector2 ( 0.213, 0.26 ), Vector2 ( 0.03, 0.03 ), self.panel.serverTab )
-	self.panel.serverTimeStep = GUI:Label ( "Time Step: N/A", Vector2 ( 0.005, 0.28 ), Vector2 ( 0.0, 0.0 ), self.panel.serverTab )
-	self.panel.serverTimeStepField = GUI:TextBox ( "", Vector2 ( 0.14, 0.28 ), Vector2 ( 0.03, 0.023 ), "numeric", self.panel.serverTab )
-	self.panel.setTimeStep = GUI:Button ( "Set", Vector2 ( 0.175, 0.28 ), Vector2 ( 0.031, 0.029 ), self.panel.serverTab, "general.settimestep" )
-	self.panel.setTimeStep:Subscribe ( "Press", self, self.setTimeStep )
-	GUI:Label ( "(0-inf)", Vector2 ( 0.21, 0.29 ), Vector2 ( 0.03, 0.03 ), self.panel.serverTab )
+	GUI:Label ( "Server:", Vector2 ( 0.0, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.main.serverTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.serverName = GUI:Label ( "Server name: N/A", Vector2 ( 0.005, 0.04 ), Vector2 ( 0.0, 0.0 ), self.panel.main.serverTab )
+	self.panel.main.serverPlayers = GUI:Label ( "Players online: N/A", Vector2 ( 0.005, 0.07 ), Vector2 ( 0.0, 0.0 ), self.panel.main.serverTab )
+	self.panel.main.serverDescription = GUI:Label ( "Description: N/A", Vector2 ( 0.005, 0.1 ), Vector2 ( 0.1, 0.03 ), self.panel.main.serverTab )
+	self.panel.main.serverSpawnPosition = GUI:Label ( "Spawn Position: N/A", Vector2 ( 0.005, 0.13 ), Vector2 ( 0.1, 0.03 ), self.panel.main.serverTab )
+	self.panel.main.serverTime = GUI:Label ( "Spawn Position: N/A", Vector2 ( 0.005, 0.16 ), Vector2 ( 0.1, 0.03 ), self.panel.main.serverTab )
+	GUI:Label ( "Game:", Vector2 ( 0.0, 0.19 ), Vector2 ( 0.2, 0.13 ), self.panel.main.serverTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.serverGameTime = GUI:Label ( "Game Time: N/A", Vector2 ( 0.005, 0.22 ), Vector2 ( 0.0, 0.0 ), self.panel.main.serverTab )
+	self.panel.main.serverGameTimeField = GUI:TextBox ( "", Vector2 ( 0.14, 0.219 ), Vector2 ( 0.03, 0.023 ), "numeric", self.panel.main.serverTab )
+	self.panel.main.setGameTime = GUI:Button ( "Set", Vector2 ( 0.175, 0.218 ), Vector2 ( 0.031, 0.029 ), self.panel.main.serverTab, "general.settime" )
+	self.panel.main.setGameTime:Subscribe ( "Press", self, self.setTime )
+	GUI:Label ( "(0-23)", Vector2 ( 0.21, 0.225 ), Vector2 ( 0.03, 0.03 ), self.panel.main.serverTab )
+	self.panel.main.serverWeather = GUI:Label ( "Weather Severity: N/A", Vector2 ( 0.005, 0.25 ), Vector2 ( 0.0, 0.0 ), self.panel.main.serverTab )
+	self.panel.main.serverWeatherField = GUI:TextBox ( "", Vector2 ( 0.14, 0.25 ), Vector2 ( 0.03, 0.023 ), "numeric", self.panel.main.serverTab )
+	self.panel.main.setWeatherSeverity = GUI:Button ( "Set", Vector2 ( 0.175, 0.25 ), Vector2 ( 0.031, 0.029 ), self.panel.main.serverTab, "general.setweather" )
+	self.panel.main.setWeatherSeverity:Subscribe ( "Press", self, self.setWeather )
+	GUI:Label ( "(0-2)", Vector2 ( 0.213, 0.26 ), Vector2 ( 0.03, 0.03 ), self.panel.main.serverTab )
+	self.panel.main.serverTimeStep = GUI:Label ( "Time Step: N/A", Vector2 ( 0.005, 0.28 ), Vector2 ( 0.0, 0.0 ), self.panel.main.serverTab )
+	self.panel.main.serverTimeStepField = GUI:TextBox ( "", Vector2 ( 0.14, 0.28 ), Vector2 ( 0.03, 0.023 ), "numeric", self.panel.main.serverTab )
+	self.panel.main.setTimeStep = GUI:Button ( "Set", Vector2 ( 0.175, 0.28 ), Vector2 ( 0.031, 0.029 ), self.panel.main.serverTab, "general.settimestep" )
+	self.panel.main.setTimeStep:Subscribe ( "Press", self, self.setTimeStep )
+	GUI:Label ( "(0-inf)", Vector2 ( 0.21, 0.29 ), Vector2 ( 0.03, 0.03 ), self.panel.main.serverTab )
 
-	self.banPanel.window = GUI:Window ( "Ban Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.24 ) )
-	self.banPanel.window:SetVisible ( false )
-	GUI:Center ( self.banPanel.window )
-	self.banPanel.reasonLabel = GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.01 ), Vector2 ( 0.19, 0.03 ), self.banPanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.banPanel.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.04 ), Vector2 ( 0.018, 0.03 ), self.banPanel.window )
-	self.banPanel.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.04 ), Vector2 ( 0.19, 0.03 ), "text", self.banPanel.window )
-	self.banPanel.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.08 ), Vector2 ( 0.21, 0.03 ), self.banPanel.window, self.reasons )
-	self.banPanel.durationLabel = GUI:Label ( "Select punishment duration", Vector2 ( 0.05, 0.13 ), Vector2 ( 0.19, 0.03 ), self.banPanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.banPanel.duration = GUI:TextBox ( "", Vector2 ( 0.0, 0.16 ), Vector2 ( 0.05, 0.03 ), "numeric", self.banPanel.window )
-	self.banPanel.durationBox = GUI:ComboBox ( Vector2 ( 0.06, 0.16 ), Vector2 ( 0.08, 0.03 ), self.banPanel.window, { "Days", "Hours", "Minutes", "Permanent" } )
-	self.banPanel.ban = GUI:Button ( "Ban", Vector2 ( 0.15, 0.16 ), Vector2 ( 0.06, 0.03 ), self.banPanel.window )
-	self.banPanel.ban:Subscribe ( "Press", self, self.banPlayer )
+	self.panel.ban.window = GUI:Window ( "Ban Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.24 ) )
+	self.panel.ban.window:SetVisible ( false )
+	GUI:Center ( self.panel.ban.window )
+	self.panel.ban.reasonLabel = GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.01 ), Vector2 ( 0.19, 0.03 ), self.panel.ban.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.ban.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.04 ), Vector2 ( 0.018, 0.03 ), self.panel.ban.window )
+	self.panel.ban.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.04 ), Vector2 ( 0.19, 0.03 ), "text", self.panel.ban.window )
+	self.panel.ban.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.08 ), Vector2 ( 0.21, 0.03 ), self.panel.ban.window, self.reasons )
+	self.panel.ban.durationLabel = GUI:Label ( "Select punishment duration", Vector2 ( 0.05, 0.13 ), Vector2 ( 0.19, 0.03 ), self.panel.ban.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.ban.duration = GUI:TextBox ( "", Vector2 ( 0.0, 0.16 ), Vector2 ( 0.05, 0.03 ), "numeric", self.panel.ban.window )
+	self.panel.ban.durationBox = GUI:ComboBox ( Vector2 ( 0.06, 0.16 ), Vector2 ( 0.08, 0.03 ), self.panel.ban.window, { "Days", "Hours", "Minutes", "Permanent" } )
+	self.panel.ban.ban = GUI:Button ( "Ban", Vector2 ( 0.15, 0.16 ), Vector2 ( 0.06, 0.03 ), self.panel.ban.window )
+	self.panel.ban.ban:Subscribe ( "Press", self, self.banPlayer )
 
-	self.kickPanel.window = GUI:Window ( "Kick Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.2 ) )
-	self.kickPanel.window:SetVisible ( false )
-	GUI:Center ( self.kickPanel.window )
-	self.kickPanel.reasonLabel = GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.01 ), Vector2 ( 0.19, 0.03 ), self.kickPanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.kickPanel.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.04 ), Vector2 ( 0.018, 0.03 ), self.kickPanel.window )
-	self.kickPanel.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.04 ), Vector2 ( 0.19, 0.03 ), "text", self.kickPanel.window )
-	self.kickPanel.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.08 ), Vector2 ( 0.21, 0.03 ), self.kickPanel.window, self.reasons )
-	self.kickPanel.kick = GUI:Button ( "Kick", Vector2 ( 0.0, 0.12 ), Vector2 ( 0.21, 0.03 ), self.kickPanel.window )
-	self.kickPanel.kick:Subscribe ( "Press", self, self.kickPlayer )
+	self.panel.kick.window = GUI:Window ( "Kick Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.2 ) )
+	self.panel.kick.window:SetVisible ( false )
+	GUI:Center ( self.panel.kick.window )
+	self.panel.kick.reasonLabel = GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.01 ), Vector2 ( 0.19, 0.03 ), self.panel.kick.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.kick.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.04 ), Vector2 ( 0.018, 0.03 ), self.panel.kick.window )
+	self.panel.kick.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.04 ), Vector2 ( 0.19, 0.03 ), "text", self.panel.kick.window )
+	self.panel.kick.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.08 ), Vector2 ( 0.21, 0.03 ), self.panel.kick.window, self.reasons )
+	self.panel.kick.kick = GUI:Button ( "Kick", Vector2 ( 0.0, 0.12 ), Vector2 ( 0.21, 0.03 ), self.panel.kick.window )
+	self.panel.kick.kick:Subscribe ( "Press", self, self.kickPlayer )
 
-	self.mutePanel.window = GUI:Window ( "Mute Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.24 ) )
-	self.mutePanel.window:SetVisible ( false )
-	GUI:Center ( self.mutePanel.window )
-	self.mutePanel.reasonLabel = GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.01 ), Vector2 ( 0.19, 0.03 ), self.mutePanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.mutePanel.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.04 ), Vector2 ( 0.018, 0.03 ), self.mutePanel.window )
-	self.mutePanel.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.04 ), Vector2 ( 0.19, 0.03 ), "text", self.mutePanel.window )
-	self.mutePanel.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.08 ), Vector2 ( 0.21, 0.03 ), self.mutePanel.window, self.reasons )
-	self.mutePanel.durationLabel = GUI:Label ( "Select punishment duration", Vector2 ( 0.05, 0.13 ), Vector2 ( 0.19, 0.03 ), self.mutePanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.mutePanel.duration = GUI:TextBox ( "", Vector2 ( 0.0, 0.16 ), Vector2 ( 0.05, 0.03 ), "numeric", self.mutePanel.window )
-	self.mutePanel.durationBox = GUI:ComboBox ( Vector2 ( 0.06, 0.16 ), Vector2 ( 0.08, 0.03 ), self.mutePanel.window, { "Minutes", "Hours", "Days" } )
-	self.mutePanel.mute = GUI:Button ( "Mute", Vector2 ( 0.15, 0.16 ), Vector2 ( 0.06, 0.03 ), self.mutePanel.window )
-	self.mutePanel.mute:Subscribe ( "Press", self, self.mutePlayer )
+	self.panel.mute.window = GUI:Window ( "Mute Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.24 ) )
+	self.panel.mute.window:SetVisible ( false )
+	GUI:Center ( self.panel.mute.window )
+	self.panel.mute.reasonLabel = GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.01 ), Vector2 ( 0.19, 0.03 ), self.panel.mute.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.mute.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.04 ), Vector2 ( 0.018, 0.03 ), self.panel.mute.window )
+	self.panel.mute.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.04 ), Vector2 ( 0.19, 0.03 ), "text", self.panel.mute.window )
+	self.panel.mute.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.08 ), Vector2 ( 0.21, 0.03 ), self.panel.mute.window, self.reasons )
+	self.panel.mute.durationLabel = GUI:Label ( "Select punishment duration", Vector2 ( 0.05, 0.13 ), Vector2 ( 0.19, 0.03 ), self.panel.mute.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.mute.duration = GUI:TextBox ( "", Vector2 ( 0.0, 0.16 ), Vector2 ( 0.05, 0.03 ), "numeric", self.panel.mute.window )
+	self.panel.mute.durationBox = GUI:ComboBox ( Vector2 ( 0.06, 0.16 ), Vector2 ( 0.08, 0.03 ), self.panel.mute.window, { "Minutes", "Hours", "Days" } )
+	self.panel.mute.mute = GUI:Button ( "Mute", Vector2 ( 0.15, 0.16 ), Vector2 ( 0.06, 0.03 ), self.panel.mute.window )
+	self.panel.mute.mute:Subscribe ( "Press", self, self.mutePlayer )
 
-	self.warpPanel.window = GUI:Window ( "Warp Player To", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.2, 0.45 ) )
-	self.warpPanel.window:SetVisible ( false )
-	GUI:Center ( self.warpPanel.window )
-	self.warpPanel.search = GUI:TextBox ( "", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.19, 0.03 ), "text", self.warpPanel.window )
-	self.warpPanel.search:Subscribe ( "TextChanged", self, self.searchWarpPlayer )
-	self.warpPanel.list = GUI:SortedList ( Vector2 ( 0.0, 0.04 ), Vector2 ( 0.19, 0.32 ), self.warpPanel.window, { { name = "Player" } } )
-	self.warpPanel.warp = GUI:Button ( "Warp", Vector2 ( 0.0, 0.37 ), Vector2 ( 0.19, 0.035 ), self.warpPanel.window )
-	self.warpPanel.warp:Subscribe ( "Press", self, self.warpPlayerTo )
+	self.panel.warp.window = GUI:Window ( "Warp Player To", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.2, 0.45 ) )
+	self.panel.warp.window:SetVisible ( false )
+	GUI:Center ( self.panel.warp.window )
+	self.panel.warp.search = GUI:TextBox ( "", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.19, 0.03 ), "text", self.panel.warp.window )
+	self.panel.warp.search:Subscribe ( "TextChanged", self, self.searchWarpPlayer )
+	self.panel.warp.list = GUI:SortedList ( Vector2 ( 0.0, 0.04 ), Vector2 ( 0.19, 0.32 ), self.panel.warp.window, { { name = "Player" } } )
+	self.panel.warp.warp = GUI:Button ( "Warp", Vector2 ( 0.0, 0.37 ), Vector2 ( 0.19, 0.035 ), self.panel.warp.window )
+	self.panel.warp.warp:Subscribe ( "Press", self, self.warpPlayerTo )
 
-	self.panel.bansList = GUI:SortedList ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.16, 0.66 ), self.panel.bansTab, { { name = "Ban" } } )
-	self.panel.bansList:Subscribe ( "RowSelected", self, self.getBanInformation )
-	self.panel.bansSearch = GUI:TextBox ( "", Vector2 ( 0.0, 0.67 ), Vector2 ( 0.16, 0.035 ), "text", self.panel.bansTab )
-	self.panel.bansSearch:Subscribe ( "TextChanged", self, self.searchBan )
-	GUI:Label ( "Ban details:", Vector2 ( 0.165, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.bansTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.banSteamID = GUI:Label ( "Steam ID: N/A", Vector2 ( 0.17, 0.04 ), Vector2 ( 0.2, 0.03 ), self.panel.bansTab )
-	self.panel.banName = GUI:Label ( "Name: N/A", Vector2 ( 0.17, 0.07 ), Vector2 ( 0.2, 0.03 ), self.panel.bansTab )
-	self.panel.banDuration = GUI:Label ( "Duration: N/A", Vector2 ( 0.17, 0.1 ), Vector2 ( 0.2, 0.03 ), self.panel.bansTab )
-	self.panel.banDate = GUI:Label ( "Date: N/A", Vector2 ( 0.17, 0.13 ), Vector2 ( 0.2, 0.03 ), self.panel.bansTab )
-	self.panel.banResponsible = GUI:Label ( "Responsible: N/A", Vector2 ( 0.17, 0.16 ), Vector2 ( 0.2, 0.03 ), self.panel.bansTab )
-	self.panel.banResponsibleSteam = GUI:Label ( "Responsible Steam ID: N/A", Vector2 ( 0.17, 0.19 ), Vector2 ( 0.2, 0.03 ), self.panel.bansTab )
-	self.panel.banReasonScroll = GUI:ScrollControl ( Vector2 ( 0.17, 0.22 ), Vector2 ( 0.2, 0.25 ), self.panel.bansTab )
-	self.panel.banReason = GUI:Label ( "Reason: N/A", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.2, 0.3 ), self.panel.banReasonScroll )
-	self.panel.banReason:SetWrap ( true )
-	self.panel.banReason:SizeToContents ( )
-	self.panel.banRemove = GUI:Button ( "Unban", Vector2 ( 0.17, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.bansTab, "ban.remove" )
-	self.panel.banRemove:Subscribe ( "Press", self, self.removeBan )
-	self.panel.banAdd = GUI:Button ( "Add ban", Vector2 ( 0.25, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.bansTab, "ban.add" )
-	self.panel.banAdd:Subscribe ( "Press", self, self.showManualBanWindow )
-	self.panel.banRefresh = GUI:Button ( "Refresh", Vector2 ( 0.33, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.bansTab )
-	self.panel.banRefresh:Subscribe ( "Press", self, self.refreshBans )
+	self.panel.main.bansList = GUI:SortedList ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.16, 0.66 ), self.panel.main.bansTab, { { name = "Ban" } } )
+	self.panel.main.bansList:Subscribe ( "RowSelected", self, self.getBanInformation )
+	self.panel.main.bansSearch = GUI:TextBox ( "", Vector2 ( 0.0, 0.67 ), Vector2 ( 0.16, 0.035 ), "text", self.panel.main.bansTab )
+	self.panel.main.bansSearch:Subscribe ( "TextChanged", self, self.searchBan )
+	GUI:Label ( "Ban details:", Vector2 ( 0.165, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.main.bansTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.banSteamID = GUI:Label ( "Steam ID: N/A", Vector2 ( 0.17, 0.04 ), Vector2 ( 0.2, 0.03 ), self.panel.main.bansTab )
+	self.panel.main.banName = GUI:Label ( "Name: N/A", Vector2 ( 0.17, 0.07 ), Vector2 ( 0.2, 0.03 ), self.panel.main.bansTab )
+	self.panel.main.banDuration = GUI:Label ( "Duration: N/A", Vector2 ( 0.17, 0.1 ), Vector2 ( 0.2, 0.03 ), self.panel.main.bansTab )
+	self.panel.main.banDate = GUI:Label ( "Date: N/A", Vector2 ( 0.17, 0.13 ), Vector2 ( 0.2, 0.03 ), self.panel.main.bansTab )
+	self.panel.main.banResponsible = GUI:Label ( "Responsible: N/A", Vector2 ( 0.17, 0.16 ), Vector2 ( 0.2, 0.03 ), self.panel.main.bansTab )
+	self.panel.main.banResponsibleSteam = GUI:Label ( "Responsible Steam ID: N/A", Vector2 ( 0.17, 0.19 ), Vector2 ( 0.2, 0.03 ), self.panel.main.bansTab )
+	self.panel.main.banReasonScroll = GUI:ScrollControl ( Vector2 ( 0.17, 0.22 ), Vector2 ( 0.2, 0.25 ), self.panel.main.bansTab )
+	self.panel.main.banReason = GUI:Label ( "Reason: N/A", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.2, 0.3 ), self.panel.main.banReasonScroll )
+	self.panel.main.banReason:SetWrap ( true )
+	self.panel.main.banReason:SizeToContents ( )
+	self.panel.main.banRemove = GUI:Button ( "Unban", Vector2 ( 0.17, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.bansTab, "ban.remove" )
+	self.panel.main.banRemove:Subscribe ( "Press", self, self.removeBan )
+	self.panel.main.banAdd = GUI:Button ( "Add ban", Vector2 ( 0.25, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.bansTab, "ban.add" )
+	self.panel.main.banAdd:Subscribe ( "Press", self, self.showManualBanWindow )
+	self.panel.main.banRefresh = GUI:Button ( "Refresh", Vector2 ( 0.33, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.bansTab )
+	self.panel.main.banRefresh:Subscribe ( "Press", self, self.refreshBans )
 
-	self.manualBanPanel.window = GUI:Window ( "Manual Ban", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.3 ) )
-	self.manualBanPanel.window:SetVisible ( false )
-	GUI:Center ( self.manualBanPanel.window )
-	GUI:Label ( "Write the Steam ID to ban", Vector2 ( 0.05, 0.001 ), Vector2 ( 0.19, 0.03 ), self.manualBanPanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.manualBanPanel.steamID = GUI:TextBox ( "", Vector2 ( 0.0, 0.025 ), Vector2 ( 0.21, 0.03 ), "text", self.manualBanPanel.window )
-	GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.07 ), Vector2 ( 0.19, 0.03 ), self.manualBanPanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.manualBanPanel.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.1 ), Vector2 ( 0.018, 0.03 ), self.manualBanPanel.window )
-	self.manualBanPanel.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.1 ), Vector2 ( 0.19, 0.03 ), "text", self.manualBanPanel.window )
-	self.manualBanPanel.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.14 ), Vector2 ( 0.21, 0.03 ), self.manualBanPanel.window, self.reasons )
-	GUI:Label ( "Select punishment duration", Vector2 ( 0.05, 0.19 ), Vector2 ( 0.19, 0.03 ), self.manualBanPanel.window ):SetTextColor ( Color ( 0, 200, 0 ) )
-	self.manualBanPanel.duration = GUI:TextBox ( "", Vector2 ( 0.0, 0.22 ), Vector2 ( 0.05, 0.03 ), "numeric", self.manualBanPanel.window )
-	self.manualBanPanel.durationBox = GUI:ComboBox ( Vector2 ( 0.06, 0.22 ), Vector2 ( 0.08, 0.03 ), self.manualBanPanel.window, { "Days", "Hours", "Minutes", "Permanent" } )
-	self.manualBanPanel.ban = GUI:Button ( "Ban", Vector2 ( 0.15, 0.22 ), Vector2 ( 0.06, 0.03 ), self.manualBanPanel.window )
-	self.manualBanPanel.ban:Subscribe ( "Press", self, self.manualBan )
+	self.panel.manualBan.window = GUI:Window ( "Manual Ban", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.22, 0.3 ) )
+	self.panel.manualBan.window:SetVisible ( false )
+	GUI:Center ( self.panel.manualBan.window )
+	GUI:Label ( "Write the Steam ID to ban", Vector2 ( 0.05, 0.001 ), Vector2 ( 0.19, 0.03 ), self.panel.manualBan.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.manualBan.steamID = GUI:TextBox ( "", Vector2 ( 0.0, 0.025 ), Vector2 ( 0.21, 0.03 ), "text", self.panel.manualBan.window )
+	GUI:Label ( "Select a reason or write one", Vector2 ( 0.05, 0.07 ), Vector2 ( 0.19, 0.03 ), self.panel.manualBan.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.manualBan.reasonCheck = GUI:CheckBox ( "", Vector2 ( 0.0, 0.1 ), Vector2 ( 0.018, 0.03 ), self.panel.manualBan.window )
+	self.panel.manualBan.reasonEdit = GUI:TextBox ( "Custom reason", Vector2 ( 0.02, 0.1 ), Vector2 ( 0.19, 0.03 ), "text", self.panel.manualBan.window )
+	self.panel.manualBan.reasonsBox = GUI:ComboBox ( Vector2 ( -0.001, 0.14 ), Vector2 ( 0.21, 0.03 ), self.panel.manualBan.window, self.reasons )
+	GUI:Label ( "Select punishment duration", Vector2 ( 0.05, 0.19 ), Vector2 ( 0.19, 0.03 ), self.panel.manualBan.window ):SetTextColor ( Color ( 0, 200, 0 ) )
+	self.panel.manualBan.duration = GUI:TextBox ( "", Vector2 ( 0.0, 0.22 ), Vector2 ( 0.05, 0.03 ), "numeric", self.panel.manualBan.window )
+	self.panel.manualBan.durationBox = GUI:ComboBox ( Vector2 ( 0.06, 0.22 ), Vector2 ( 0.08, 0.03 ), self.panel.manualBan.window, { "Days", "Hours", "Minutes", "Permanent" } )
+	self.panel.manualBan.ban = GUI:Button ( "Ban", Vector2 ( 0.15, 0.22 ), Vector2 ( 0.06, 0.03 ), self.panel.manualBan.window )
+	self.panel.manualBan.ban:Subscribe ( "Press", self, self.manualBan )
 
-	self.shoutPanel.window = GUI:Window ( "Shout Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.25, 0.16 ) )
-	self.shoutPanel.window:SetVisible ( false )
-	GUI:Center ( self.shoutPanel.window )
-	self.shoutPanel.message = GUI:TextBox ( "", Vector2 ( 0.0, 0.01 ), Vector2 ( 0.24, 0.05 ), "text", self.shoutPanel.window )
-	self.shoutPanel.shout = GUI:Button ( "Shout!", Vector2 ( 0.0, 0.07 ), Vector2 ( 0.24, 0.04 ), self.shoutPanel.window )
-	self.shoutPanel.shout:Subscribe ( "Press", self, self.shoutPlayer )
+	self.panel.shout.window = GUI:Window ( "Shout Player", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.25, 0.16 ) )
+	self.panel.shout.window:SetVisible ( false )
+	GUI:Center ( self.panel.shout.window )
+	self.panel.shout.message = GUI:TextBox ( "", Vector2 ( 0.0, 0.01 ), Vector2 ( 0.24, 0.05 ), "text", self.panel.shout.window )
+	self.panel.shout.shout = GUI:Button ( "Shout!", Vector2 ( 0.0, 0.07 ), Vector2 ( 0.24, 0.04 ), self.panel.shout.window )
+	self.panel.shout.shout:Subscribe ( "Press", self, self.shoutPlayer )
 
-	self.panel.chatScroll = GUI:ScrollControl ( Vector2 ( 0.0, 0.01 ), Vector2 ( 0.48, 0.6 ), self.panel.adminchatTab )
-	self.panel.chatMessages = GUI:Label ( "", Vector2 ( 0.0, 0.011 ), Vector2 ( 0.48, 0.0 ), self.panel.chatScroll )
-	self.panel.chatMessages:SetWrap ( true )
-	self.panel.chatMessage = GUI:TextBox ( "", Vector2 ( 0.0, 0.66 ), Vector2 ( 0.38, 0.04 ), "text", self.panel.adminchatTab )
-	self.panel.chatMessage:Subscribe ( "ReturnPressed", self, self.sendChatMessage )
-	self.panel.sendMessage = GUI:Button ( "Send", Vector2 ( 0.385, 0.66 ), Vector2 ( 0.05, 0.04 ), self.panel.adminchatTab )
-	self.panel.sendMessage:Subscribe ( "Press", self, self.sendChatMessage )
-	self.panel.clearMessage = GUI:Button ( "Clear", Vector2 ( 0.44, 0.66 ), Vector2 ( 0.04, 0.04 ), self.panel.adminchatTab )
-	self.panel.clearMessage:Subscribe ( "Press", self, self.clearChatMessage )
+	self.panel.main.chatScroll = GUI:ScrollControl ( Vector2 ( 0.0, 0.01 ), Vector2 ( 0.48, 0.6 ), self.panel.main.adminchatTab )
+	self.panel.main.chatMessages = GUI:Label ( "", Vector2 ( 0.0, 0.011 ), Vector2 ( 0.48, 0.0 ), self.panel.main.chatScroll )
+	self.panel.main.chatMessages:SetWrap ( true )
+	self.panel.main.chatMessage = GUI:TextBox ( "", Vector2 ( 0.0, 0.66 ), Vector2 ( 0.38, 0.04 ), "text", self.panel.main.adminchatTab )
+	self.panel.main.chatMessage:Subscribe ( "ReturnPressed", self, self.sendChatMessage )
+	self.panel.main.sendMessage = GUI:Button ( "Send", Vector2 ( 0.385, 0.66 ), Vector2 ( 0.05, 0.04 ), self.panel.main.adminchatTab )
+	self.panel.main.sendMessage:Subscribe ( "Press", self, self.sendChatMessage )
+	self.panel.main.clearMessage = GUI:Button ( "Clear", Vector2 ( 0.44, 0.66 ), Vector2 ( 0.04, 0.04 ), self.panel.main.adminchatTab )
+	self.panel.main.clearMessage:Subscribe ( "Press", self, self.clearChatMessage )
 
-	self.panel.aclTree = GUI:Tree ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.2, 0.71 ), self.panel.aclTab )
-	self.panel.aclDataLabel = GUI:Label ( "Group name: N/A\n\nCreator: N/A\n\nCreation date: N/A\n\nGroup objects: N/A", Vector2 ( 0.205, 0.01 ), Vector2 ( 0.0, 0.0 ), self.panel.aclTab )
-	self.panel.aclDataLabel:SizeToContents ( )
-	self.panel.aclCreateGroup = GUI:Button ( "Create group", Vector2 ( 0.21, 0.64 ), Vector2 ( 0.1, 0.03 ), self.panel.aclTab )
-	self.panel.aclCreateGroup:Subscribe ( "Press", self, self.showACLCreateWindow )
-	self.panel.aclDestroyGroup = GUI:Button ( "Destroy group", Vector2 ( 0.21, 0.68 ), Vector2 ( 0.1, 0.03 ), self.panel.aclTab )
-	self.panel.aclDestroyGroup:Subscribe ( "Press", self, self.destroyACLGroup )
-	self.panel.aclAddObject = GUI:Button ( "Add object", Vector2 ( 0.32, 0.64 ), Vector2 ( 0.1, 0.03 ), self.panel.aclTab )
-	self.panel.aclAddObject:Subscribe ( "Press", self, self.showACLAddObjectWindow )
-	self.panel.aclRemoveObject = GUI:Button ( "Remove object", Vector2 ( 0.32, 0.68 ), Vector2 ( 0.1, 0.03 ), self.panel.aclTab )
-	self.panel.aclRemoveObject:Subscribe ( "Press", self, self.removeACLObject )
+	self.panel.main.aclTree = GUI:Tree ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.2, 0.71 ), self.panel.main.aclTab )
+	self.panel.main.aclDataLabel = GUI:Label ( "Group name: N/A\n\nCreator: N/A\n\nCreation date: N/A\n\nGroup objects: N/A", Vector2 ( 0.205, 0.01 ), Vector2 ( 0.0, 0.0 ), self.panel.main.aclTab )
+	self.panel.main.aclDataLabel:SizeToContents ( )
+	self.panel.main.aclCreateGroup = GUI:Button ( "Create group", Vector2 ( 0.21, 0.64 ), Vector2 ( 0.1, 0.03 ), self.panel.main.aclTab )
+	self.panel.main.aclCreateGroup:Subscribe ( "Press", self, self.showACLCreateWindow )
+	self.panel.main.aclDestroyGroup = GUI:Button ( "Destroy group", Vector2 ( 0.21, 0.68 ), Vector2 ( 0.1, 0.03 ), self.panel.main.aclTab )
+	self.panel.main.aclDestroyGroup:Subscribe ( "Press", self, self.destroyACLGroup )
+	self.panel.main.aclAddObject = GUI:Button ( "Add object", Vector2 ( 0.32, 0.64 ), Vector2 ( 0.1, 0.03 ), self.panel.main.aclTab )
+	self.panel.main.aclAddObject:Subscribe ( "Press", self, self.showACLAddObjectWindow )
+	self.panel.main.aclRemoveObject = GUI:Button ( "Remove object", Vector2 ( 0.32, 0.68 ), Vector2 ( 0.1, 0.03 ), self.panel.main.aclTab )
+	self.panel.main.aclRemoveObject:Subscribe ( "Press", self, self.removeACLObject )
 
-	self.permPanelChange.window = GUI:Window ( "ACL Permission", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.15, 0.2 ) )
-	self.permPanelChange.window:SetVisible ( false )
-	GUI:Center ( self.permPanelChange.window )
-	self.permPanelChange.label = GUI:Label ( "Permission:", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.14, 0.1 ), self.permPanelChange.window )
-	GUI:Label ( "Accepted values: true/false", Vector2 ( 0.0, 0.03 ), Vector2 ( 0.2, 0.1 ), self.permPanelChange.window )
-	self.permPanelChange.value = GUI:TextBox ( "", Vector2 ( 0.01, 0.07 ), Vector2 ( 0.12, 0.03 ), "text", self.permPanelChange.window )
-	self.permPanelChange.set = GUI:Button ( "Set permission", Vector2 ( 0.01, 0.12 ), Vector2 ( 0.12, 0.03 ), self.permPanelChange.window )
-	self.permPanelChange.set:Subscribe ( "Press", self, self.modifyACLPermission )
+	self.panel.permChange.window = GUI:Window ( "ACL Permission", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.15, 0.2 ) )
+	self.panel.permChange.window:SetVisible ( false )
+	GUI:Center ( self.panel.permChange.window )
+	self.panel.permChange.label = GUI:Label ( "Permission:", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.14, 0.1 ), self.panel.permChange.window )
+	GUI:Label ( "Accepted values: true/false", Vector2 ( 0.0, 0.03 ), Vector2 ( 0.2, 0.1 ), self.panel.permChange.window )
+	self.panel.permChange.value = GUI:TextBox ( "", Vector2 ( 0.01, 0.07 ), Vector2 ( 0.12, 0.03 ), "text", self.panel.permChange.window )
+	self.panel.permChange.set = GUI:Button ( "Set permission", Vector2 ( 0.01, 0.12 ), Vector2 ( 0.12, 0.03 ), self.panel.permChange.window )
+	self.panel.permChange.set:Subscribe ( "Press", self, self.modifyACLPermission )
 
-	self.aclCreatePanel.window = GUI:Window ( "Create ACL Group", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.25, 0.45 ) )
-	self.aclCreatePanel.window:SetVisible ( false )
-	GUI:Center ( self.aclCreatePanel.window )
-	GUI:Label ( "Group name:", Vector2 ( 0.001, 0.001 ), Vector2 ( 0.1, 0.03 ), self.aclCreatePanel.window )
-	self.aclCreatePanel.name = GUI:TextBox ( "", Vector2 ( 0.001, 0.03 ), Vector2 ( 0.24, 0.03 ), "text", self.aclCreatePanel.window )
-	self.aclCreatePanel.permissions = GUI:SortedList ( Vector2 ( 0.0, 0.07 ), Vector2 ( 0.24, 0.27 ), self.aclCreatePanel.window, { { name = "Permission" } } )
-	self.aclCreatePanel.select = GUI:Button ( "Select", Vector2 ( 0.0, 0.34 ), Vector2 ( 0.12, 0.03 ), self.aclCreatePanel.window )
-	self.aclCreatePanel.select:Subscribe ( "Press", self, self.onPermissionSelect )
-	self.aclCreatePanel.selectAll = GUI:Button ( "Select all", Vector2 ( 0.12, 0.34 ), Vector2 ( 0.12, 0.03 ), self.aclCreatePanel.window )
-	self.aclCreatePanel.selectAll:Subscribe ( "Press", self, self.onPermissionSelectAll )
-	self.aclCreatePanel.create = GUI:Button ( "Create Group", Vector2 ( 0.0, 0.37 ), Vector2 ( 0.24, 0.03 ), self.aclCreatePanel.window )
-	self.aclCreatePanel.create:Subscribe ( "Press", self, self.createACLGroup )
+	self.panel.aclCreate.window = GUI:Window ( "Create ACL Group", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.25, 0.45 ) )
+	self.panel.aclCreate.window:SetVisible ( false )
+	GUI:Center ( self.panel.aclCreate.window )
+	GUI:Label ( "Group name:", Vector2 ( 0.001, 0.001 ), Vector2 ( 0.1, 0.03 ), self.panel.aclCreate.window )
+	self.panel.aclCreate.name = GUI:TextBox ( "", Vector2 ( 0.001, 0.03 ), Vector2 ( 0.24, 0.03 ), "text", self.panel.aclCreate.window )
+	self.panel.aclCreate.permissions = GUI:SortedList ( Vector2 ( 0.0, 0.07 ), Vector2 ( 0.24, 0.27 ), self.panel.aclCreate.window, { { name = "Permission" } } )
+	self.panel.aclCreate.select = GUI:Button ( "Select", Vector2 ( 0.0, 0.34 ), Vector2 ( 0.12, 0.03 ), self.panel.aclCreate.window )
+	self.panel.aclCreate.select:Subscribe ( "Press", self, self.onPermissionSelect )
+	self.panel.aclCreate.selectAll = GUI:Button ( "Select all", Vector2 ( 0.12, 0.34 ), Vector2 ( 0.12, 0.03 ), self.panel.aclCreate.window )
+	self.panel.aclCreate.selectAll:Subscribe ( "Press", self, self.onPermissionSelectAll )
+	self.panel.aclCreate.create = GUI:Button ( "Create Group", Vector2 ( 0.0, 0.37 ), Vector2 ( 0.24, 0.03 ), self.panel.aclCreate.window )
+	self.panel.aclCreate.create:Subscribe ( "Press", self, self.createACLGroup )
 
-	self.aclObjectPanel.window = GUI:Window ( "Add Object to: ", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.15, 0.15 ) )
-	self.aclObjectPanel.window:SetVisible ( false )
-	GUI:Center ( self.aclObjectPanel.window )
-	GUI:Label ( "Steam ID to add:", Vector2 ( 0.001, 0.001 ), Vector2 ( 0.1, 0.03 ), self.aclObjectPanel.window )
-	self.aclObjectPanel.value = GUI:TextBox ( "", Vector2 ( 0.0, 0.03 ), Vector2 ( 0.14, 0.03 ), "text", self.aclObjectPanel.window )
-	self.aclObjectPanel.add = GUI:Button ( "Add", Vector2 ( 0.0, 0.07 ), Vector2 ( 0.14, 0.03 ), self.aclObjectPanel.window )
-	self.aclObjectPanel.add:Subscribe ( "Press", self, self.addACLObject )
+	self.panel.aclObject.window = GUI:Window ( "Add Object to: ", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.15, 0.15 ) )
+	self.panel.aclObject.window:SetVisible ( false )
+	GUI:Center ( self.panel.aclObject.window )
+	GUI:Label ( "Steam ID to add:", Vector2 ( 0.001, 0.001 ), Vector2 ( 0.1, 0.03 ), self.panel.aclObject.window )
+	self.panel.aclObject.value = GUI:TextBox ( "", Vector2 ( 0.0, 0.03 ), Vector2 ( 0.14, 0.03 ), "text", self.panel.aclObject.window )
+	self.panel.aclObject.add = GUI:Button ( "Add", Vector2 ( 0.0, 0.07 ), Vector2 ( 0.14, 0.03 ), self.panel.aclObject.window )
+	self.panel.aclObject.add:Subscribe ( "Press", self, self.addACLObject )
 
-	self.panel.modulesList = GUI:SortedList ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.16, 0.66 ), self.panel.modulesTab, { { name = "Module" } } )
-	self.panel.modulesSearch = GUI:TextBox ( "", Vector2 ( 0.0, 0.67 ), Vector2 ( 0.16, 0.035 ), "text", self.panel.modulesTab )
-	self.panel.modulesSearch:Subscribe ( "TextChanged", self, self.searchModule )
-	GUI:Label ( "Module log:", Vector2 ( 0.165, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.modulesTab ):SetTextColor ( Color ( 255, 0, 0 ) )
-	self.panel.modulesLogScroll = GUI:ScrollControl ( Vector2 ( 0.17, 0.04 ), Vector2 ( 0.34, 0.5 ), self.panel.modulesTab )
-	self.panel.modulesLog = GUI:Label ( "", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.34, 0.5 ), self.panel.modulesLogScroll )
-	self.panel.modulesLog:SetWrap ( true )
-	self.panel.moduleLoad = GUI:Button ( "Load", Vector2 ( 0.17, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.modulesTab, "module.load" )
-	self.panel.moduleLoad:Subscribe ( "Press", self, self.loadModule )
-	self.panel.moduleReload = GUI:Button ( "Reload", Vector2 ( 0.25, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.modulesTab, "module.load" )
-	self.panel.moduleReload:Subscribe ( "Press", self, self.reloadModule )
-	self.panel.moduleUnload = GUI:Button ( "Unload", Vector2 ( 0.33, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.modulesTab, "module.unload" )
-	self.panel.moduleUnload:Subscribe ( "Press", self, self.unloadModule )
-	self.panel.modulesRefresh = GUI:Button ( "Refresh", Vector2 ( 0.41, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.modulesTab )
-	self.panel.modulesRefresh:Subscribe ( "Press", self, self.refreshModules )
+	self.panel.main.modulesList = GUI:SortedList ( Vector2 ( 0.0, 0.0 ), Vector2 ( 0.16, 0.66 ), self.panel.main.modulesTab, { { name = "Module" } } )
+	self.panel.main.modulesSearch = GUI:TextBox ( "", Vector2 ( 0.0, 0.67 ), Vector2 ( 0.16, 0.035 ), "text", self.panel.main.modulesTab )
+	self.panel.main.modulesSearch:Subscribe ( "TextChanged", self, self.searchModule )
+	GUI:Label ( "Module log:", Vector2 ( 0.165, 0.01 ), Vector2 ( 0.2, 0.1 ), self.panel.main.modulesTab ):SetTextColor ( Color ( 255, 0, 0 ) )
+	self.panel.main.modulesLogScroll = GUI:ScrollControl ( Vector2 ( 0.17, 0.04 ), Vector2 ( 0.34, 0.5 ), self.panel.main.modulesTab )
+	self.panel.main.modulesLog = GUI:Label ( "", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.34, 0.5 ), self.panel.main.modulesLogScroll )
+	self.panel.main.modulesLog:SetWrap ( true )
+	self.panel.main.moduleLoad = GUI:Button ( "Load", Vector2 ( 0.17, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.modulesTab, "module.load" )
+	self.panel.main.moduleLoad:Subscribe ( "Press", self, self.loadModule )
+	self.panel.main.moduleReload = GUI:Button ( "Reload", Vector2 ( 0.25, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.modulesTab, "module.load" )
+	self.panel.main.moduleReload:Subscribe ( "Press", self, self.reloadModule )
+	self.panel.main.moduleUnload = GUI:Button ( "Unload", Vector2 ( 0.33, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.modulesTab, "module.unload" )
+	self.panel.main.moduleUnload:Subscribe ( "Press", self, self.unloadModule )
+	self.panel.main.modulesRefresh = GUI:Button ( "Refresh", Vector2 ( 0.41, 0.67 ), Vector2 ( 0.07, 0.035 ), self.panel.main.modulesTab )
+	self.panel.main.modulesRefresh:Subscribe ( "Press", self, self.refreshModules )
 
-	self.vehColorPanel.window = GUI:Window ( "Vehicle Colour", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.3, 0.36 ) )
-	GUI:Center ( self.vehColorPanel.window )
-	self.vehColorPanel.window:SetVisible ( false )
-	self.vehColorPanel.tabPanel, self.vehColorPanel.tabs = GUI:TabControl ( { "Tone 1", "Tone 2" }, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.0, 0.0 ), self.vehColorPanel.window )
-	self.vehColorPanel.tabPanel:SetDock ( GwenPosition.Fill )
-	self.vehColorPanel.tone1 = GUI:ColorPicker ( true, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.3, 0.23 ), self.vehColorPanel.tabs [ "tone 1" ].base )
-	self.vehColorPanel.tone1Set = GUI:Button ( "Set colour", Vector2 ( 0.0, 0.24 ), Vector2 ( 0.282, 0.03 ), self.vehColorPanel.tabs [ "tone 1" ].base )
-	self.vehColorPanel.tone1Set:Subscribe ( "Press", self, self.setVehicleTone1Colour )
-	self.vehColorPanel.tone2 = GUI:ColorPicker ( true, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.3, 0.23 ), self.vehColorPanel.tabs [ "tone 2" ].base )
-	self.vehColorPanel.tone2Set = GUI:Button ( "Set colour", Vector2 ( 0.0, 0.24 ), Vector2 ( 0.282, 0.03 ), self.vehColorPanel.tabs [ "tone 2" ].base )
-	self.vehColorPanel.tone2Set:Subscribe ( "Press", self, self.setVehicleTone2Colour )
+	self.panel.vehColor.window = GUI:Window ( "Vehicle Colour", Vector2 ( 0.0, 0.0 ), Vector2 ( 0.3, 0.36 ) )
+	GUI:Center ( self.panel.vehColor.window )
+	self.panel.vehColor.window:SetVisible ( false )
+	self.panel.vehColor.tabPanel, self.vehColorTabs = GUI:TabControl ( { "Tone 1", "Tone 2" }, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.0, 0.0 ), self.panel.vehColor.window )
+	self.panel.vehColor.tabPanel:SetDock ( GwenPosition.Fill )
+	self.panel.vehColor.tone1 = GUI:ColorPicker ( true, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.3, 0.23 ), self.vehColorTabs [ "tone 1" ].base )
+	self.panel.vehColor.tone1Set = GUI:Button ( "Set colour", Vector2 ( 0.0, 0.24 ), Vector2 ( 0.282, 0.03 ), self.vehColorTabs [ "tone 1" ].base )
+	self.panel.vehColor.tone1Set:Subscribe ( "Press", self, self.setVehicleTone1Colour )
+	self.panel.vehColor.tone2 = GUI:ColorPicker ( true, Vector2 ( 0.0, 0.0 ), Vector2 ( 0.3, 0.23 ), self.vehColorTabs [ "tone 2" ].base )
+	self.panel.vehColor.tone2Set = GUI:Button ( "Set colour", Vector2 ( 0.0, 0.24 ), Vector2 ( 0.282, 0.03 ), self.vehColorTabs [ "tone 2" ].base )
+	self.panel.vehColor.tone2Set:Subscribe ( "Press", self, self.setVehicleTone2Colour )
 
 	-- Normal events
 	Events:Subscribe ( "KeyUp", self, self.onKeyPress )
 	Events:Subscribe ( "PlayerJoin", self, self.onPlayerJoin )
 	Events:Subscribe ( "PlayerQuit", self, self.onPlayerQuit )
 	Events:Subscribe ( "LocalPlayerInput", self, self.disableControls )
+	-- Events:Subscribe ( "ModuleUnload", self, self.onModuleUnload )
 	-- Network events
 	Network:Send ( "admin.requestPermissions" )
 	Network:Subscribe ( "admin.returnPermissions", self, self.returnPermissions )
@@ -367,7 +370,7 @@ function Admin:setActive ( state )
 	if ( state == true ) then
 		Network:Send ( "admin.isAdmin" )
 	else
-		self.panel.window:SetVisible ( false )
+		self.panel.main.window:SetVisible ( false )
 		Mouse:SetVisible ( false )
 		self.active = false
 		if ( updateDataEvent ) then
@@ -393,7 +396,7 @@ function Admin:onPanelClose ( )
 end
 
 function Admin:showPanel ( data )
-	self.panel.window:SetVisible ( true )
+	self.panel.main.window:SetVisible ( true )
 	Mouse:SetVisible ( true )
 	self.active = true
 	self:loadPlayersToList ( )
@@ -418,13 +421,13 @@ function Admin:returnPermissions ( perms )
 end
 
 function Admin:addPlayerToList ( player )
-	local item = self.panel.playersList:AddItem ( player:GetName ( ) )
+	local item = self.panel.main.playersList:AddItem ( player:GetName ( ) )
 	item:SetDataObject ( "id", player )
 	self.players [ tostring ( player:GetSteamId ( ) ) ] = item
 end
 
 function Admin:loadPlayersToList ( )
-	self.panel.playersList:Clear ( )
+	self.panel.main.playersList:Clear ( )
 	self:addPlayerToList ( LocalPlayer )
 	for player in Client:GetPlayers ( ) do
 		self:addPlayerToList ( player )
@@ -432,7 +435,7 @@ function Admin:loadPlayersToList ( )
 end
 
 function Admin:getInformation ( )
-	local row = self.panel.playersList:GetSelectedRow ( )
+	local row = self.panel.main.playersList:GetSelectedRow ( )
 	if ( row ) then
 		local player = row:GetDataObject ( "id" )
 		if IsValid ( player, false ) then
@@ -443,24 +446,24 @@ end
 
 function Admin:displayInformation ( data )
 	if ( type ( data ) == "table" ) then
-		self.panel.playerName:SetText ( "Name: ".. tostring ( data.name ) )
-		self.panel.playerSteamID:SetText ( "Steam ID: ".. tostring ( data.steamID ) )
-		self.panel.playerIP:SetText ( "IP: ".. tostring ( data.ip ) )
-		self.panel.playerGroups:SetText ( "Groups: ".. tostring ( data.groups ) )
-		self.panel.playerPing:SetText ( "Ping: ".. tostring ( data.ping ) )
-		self.panel.playerHealth:SetText ( "Health: ".. tostring ( data.health ) )
-		self.panel.playerMoney:SetText ( "Money: ".. tostring ( data.money ) )
-		self.panel.playerPosition:SetText ( "Position: ".. tostring ( data.position ) )
-		self.panel.playerAngle:SetText ( "Angle: ".. tostring ( data.angle ) )
-		self.panel.playerWorld:SetText ( "World: ".. tostring ( data.world ) )
-		self.panel.playerModel:SetText ( "Model: ".. tostring ( data.model ) )
-		self.panel.playerVehicle:SetText ( "Name: ".. tostring ( data.vehicle ) )
-		self.panel.playerVehicleHealth:SetText ( "Health: ".. tostring ( data.vehicleHealth ) )
-		self.panel.playerWeapon:SetText ( "Weapon: ".. tostring ( data.weapon ) )
-		self.panel.playerWeaponAmmo:SetText ( "Weapon ammo: ".. tostring ( data.weaponAmmo ) )
-		self.panel.mute:SetText ( ( data.muted == true and "Unmute" or "Mute" ) )
-		self.panel.freeze:SetText ( ( data.frozen == true and "Unfreeze" or "Freeze" ) )
-		self.panel.giveAdmin:SetText ( ( data.isAdmin == true and "Revoke admin rights" or "Give admin rights" ) )
+		self.panel.main.playerName:SetText ( "Name: ".. tostring ( data.name ) )
+		self.panel.main.playerSteamID:SetText ( "Steam ID: ".. tostring ( data.steamID ) )
+		self.panel.main.playerIP:SetText ( "IP: ".. tostring ( data.ip ) )
+		self.panel.main.playerGroups:SetText ( "Groups: ".. tostring ( data.groups ) )
+		self.panel.main.playerPing:SetText ( "Ping: ".. tostring ( data.ping ) )
+		self.panel.main.playerHealth:SetText ( "Health: ".. tostring ( data.health ) )
+		self.panel.main.playerMoney:SetText ( "Money: ".. tostring ( data.money ) )
+		self.panel.main.playerPosition:SetText ( "Position: ".. tostring ( data.position ) )
+		self.panel.main.playerAngle:SetText ( "Angle: ".. tostring ( data.angle ) )
+		self.panel.main.playerWorld:SetText ( "World: ".. tostring ( data.world ) )
+		self.panel.main.playerModel:SetText ( "Model: ".. tostring ( data.model ) )
+		self.panel.main.playerVehicle:SetText ( "Name: ".. tostring ( data.vehicle ) )
+		self.panel.main.playerVehicleHealth:SetText ( "Health: ".. tostring ( data.vehicleHealth ) )
+		self.panel.main.playerWeapon:SetText ( "Weapon: ".. tostring ( data.weapon ) )
+		self.panel.main.playerWeaponAmmo:SetText ( "Weapon ammo: ".. tostring ( data.weaponAmmo ) )
+		self.panel.main.mute:SetText ( ( data.muted == true and "Unmute" or "Mute" ) )
+		self.panel.main.freeze:SetText ( ( data.frozen == true and "Unfreeze" or "Freeze" ) )
+		self.panel.main.giveAdmin:SetText ( ( data.isAdmin == true and "Revoke admin rights" or "Give admin rights" ) )
 	end
 end
 
@@ -471,7 +474,7 @@ end
 function Admin:onPlayerQuit ( args )
 	local steamID = tostring ( args.player:GetSteamId ( ) )
 	if ( self.players [ steamID ] ) then
-		self.panel.playersList:RemoveItem ( self.players [ steamID ] )
+		self.panel.main.playersList:RemoveItem ( self.players [ steamID ] )
 		self.players [ steamID ] = nil
 	end
 end
@@ -479,22 +482,22 @@ end
 function Admin:displayServerInfo ( info )
 	self.serverInfo = info
 	local timeTable = tostring ( math.round ( Game:GetTime ( ), 1 ) ):split ( "." )
-	self.panel.serverName:SetText ( "Server Name: ".. tostring ( info.name ) )
-	self.panel.serverName:SizeToContents ( )
-	self.panel.serverPlayers:SetText ( "Players: ".. tostring ( self:countPlayers ( ) ) .."/".. tostring ( info.maxPlayers ) )
-	self.panel.serverPlayers:SizeToContents ( )
-	self.panel.serverDescription:SetText ( "Description: ".. tostring ( info.description ) )
-	self.panel.serverDescription:SizeToContents ( )
-	self.panel.serverSpawnPosition:SetText ( "Spawn Position: ".. tostring ( info.spawnPosition ) )
-	self.panel.serverSpawnPosition:SizeToContents ( )
-	self.panel.serverTime:SetText ( "Server Time: ".. tostring ( info.serverTime ) )
-	self.panel.serverTime:SizeToContents ( )
-	self.panel.serverGameTime:SetText ( "Game Time: ".. string.format ( "%02d:%02d", ( timeTable [ 1 ] or 0 ), ( timeTable [ 2 ] or 0 ) ) )
-	self.panel.serverGameTime:SizeToContents ( )
-	self.panel.serverWeather:SetText ( "Weather Severity: ".. tostring ( info.weatherSeverity ) )
-	self.panel.serverWeather:SizeToContents ( )
-	self.panel.serverTimeStep:SetText ( "Time Step: ".. tostring ( info.timeStep ) )
-	self.panel.serverTimeStep:SizeToContents ( )
+	self.panel.main.serverName:SetText ( "Server Name: ".. tostring ( info.name ) )
+	self.panel.main.serverName:SizeToContents ( )
+	self.panel.main.serverPlayers:SetText ( "Players: ".. tostring ( self:countPlayers ( ) ) .."/".. tostring ( info.maxPlayers ) )
+	self.panel.main.serverPlayers:SizeToContents ( )
+	self.panel.main.serverDescription:SetText ( "Description: ".. tostring ( info.description ) )
+	self.panel.main.serverDescription:SizeToContents ( )
+	self.panel.main.serverSpawnPosition:SetText ( "Spawn Position: ".. tostring ( info.spawnPosition ) )
+	self.panel.main.serverSpawnPosition:SizeToContents ( )
+	self.panel.main.serverTime:SetText ( "Server Time: ".. tostring ( info.serverTime ) )
+	self.panel.main.serverTime:SizeToContents ( )
+	self.panel.main.serverGameTime:SetText ( "Game Time: ".. string.format ( "%02d:%02d", ( timeTable [ 1 ] or 0 ), ( timeTable [ 2 ] or 0 ) ) )
+	self.panel.main.serverGameTime:SizeToContents ( )
+	self.panel.main.serverWeather:SetText ( "Weather Severity: ".. tostring ( info.weatherSeverity ) )
+	self.panel.main.serverWeather:SizeToContents ( )
+	self.panel.main.serverTimeStep:SetText ( "Time Step: ".. tostring ( info.timeStep ) )
+	self.panel.main.serverTimeStep:SizeToContents ( )
 end
 
 function Admin:updateData ( )
@@ -515,7 +518,7 @@ function Admin:updateData ( )
 end
 
 function Admin:searchPlayer ( )
-	local text = self.panel.playersSearch:GetText ( ):lower ( )
+	local text = self.panel.main.playersSearch:GetText ( ):lower ( )
 	if ( text:len ( ) > 0 ) then
 		for _, item in pairs ( self.players ) do
 			item:SetVisible ( false )
@@ -531,9 +534,9 @@ function Admin:searchPlayer ( )
 end
 
 function Admin:showBanWindow ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		self.banPanel.window:SetVisible ( true )
+		self.panel.ban.window:SetVisible ( true )
 		self.victim = player
 	else
 		self:Message ( "No player selected.", "err" )
@@ -542,9 +545,9 @@ end
 
 function Admin:banPlayer ( )
 	if IsValid ( self.victim, false ) then
-		local reason = ( self.banPanel.reasonCheck:GetChecked ( ) == true and self.banPanel.reasonEdit:GetText ( ) or self.banPanel.reasonsBox:GetSelectedItem ( ):GetText ( ) )
-		local durationMethod = self.banPanel.durationBox:GetSelectedItem ( ):GetText ( )
-		local duration = tonumber ( self.banPanel.duration:GetText ( ) )
+		local reason = ( self.panel.ban.reasonCheck:GetChecked ( ) == true and self.panel.ban.reasonEdit:GetText ( ) or self.panel.ban.reasonsBox:GetSelectedItem ( ):GetText ( ) )
+		local durationMethod = self.panel.ban.durationBox:GetSelectedItem ( ):GetText ( )
+		local duration = tonumber ( self.panel.ban.duration:GetText ( ) )
 		if ( not duration or duration < 0 or durationMethod == "Permanent" ) then
 			duration = 0
 		end
@@ -558,16 +561,16 @@ function Admin:banPlayer ( )
 
 		Network:Send ( "admin.executeAction", { "player.ban", self.victim, reason, duration } )
 		self.victim = false
-		self.banPanel.window:SetVisible ( false )
+		self.panel.ban.window:SetVisible ( false )
 	else
 		self:Message ( "No player selected.", "err" )
 	end
 end
 
 function Admin:showKickWindow ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		self.kickPanel.window:SetVisible ( true )
+		self.panel.kick.window:SetVisible ( true )
 		self.victim = player
 	else
 		self:Message ( "No player selected.", "err" )
@@ -576,20 +579,20 @@ end
 
 function Admin:kickPlayer ( )
 	if IsValid ( self.victim, false ) then
-		local reason = ( self.kickPanel.reasonCheck:GetChecked ( ) == true and self.kickPanel.reasonEdit:GetText ( ) or self.kickPanel.reasonsBox:GetSelectedItem ( ):GetText ( ) )
+		local reason = ( self.panel.kick.reasonCheck:GetChecked ( ) == true and self.panel.kick.reasonEdit:GetText ( ) or self.panel.kick.reasonsBox:GetSelectedItem ( ):GetText ( ) )
 		Network:Send ( "admin.executeAction", { "player.kick", self.victim, reason } )
 		self.victim = false
-		self.kickPanel.window:SetVisible ( false )
+		self.panel.kick.window:SetVisible ( false )
 	else
 		self:Message ( "No player selected.", "err" )
 	end
 end
 
 function Admin:showMuteWindow ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		if ( self.panel.mute:GetText ( ) == "Mute" ) then
-			self.mutePanel.window:SetVisible ( true )
+		if ( self.panel.main.mute:GetText ( ) == "Mute" ) then
+			self.panel.mute.window:SetVisible ( true )
 			self.victim = player
 		else
 			Network:Send ( "admin.executeAction", { "player.mute", player } )
@@ -601,9 +604,9 @@ end
 
 function Admin:mutePlayer ( )
 	if IsValid ( self.victim, false ) then
-		local reason = ( self.mutePanel.reasonCheck:GetChecked ( ) == true and self.mutePanel.reasonEdit:GetText ( ) or self.mutePanel.reasonsBox:GetSelectedItem ( ):GetText ( ) )
-		local durationMethod = self.mutePanel.durationBox:GetSelectedItem ( ):GetText ( )
-		local duration = tonumber ( self.mutePanel.duration:GetText ( ) )
+		local reason = ( self.panel.mute.reasonCheck:GetChecked ( ) == true and self.panel.mute.reasonEdit:GetText ( ) or self.panel.mute.reasonsBox:GetSelectedItem ( ):GetText ( ) )
+		local durationMethod = self.panel.mute.durationBox:GetSelectedItem ( ):GetText ( )
+		local duration = tonumber ( self.panel.mute.duration:GetText ( ) )
 		if ( not duration or duration < 1 ) then
 			duration = 0.1
 		end
@@ -615,14 +618,14 @@ function Admin:mutePlayer ( )
 
 		Network:Send ( "admin.executeAction", { "player.mute", self.victim, reason, ( duration * 60 ) } )
 		self.victim = false
-		self.mutePanel.window:SetVisible ( false )
+		self.panel.mute.window:SetVisible ( false )
 	else
 		self:Message ( "No player selected.", "err" )
 	end
 end
 
 function Admin:freezePlayer ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		Network:Send ( "admin.executeAction", { "player.freeze", player } )
 	else
@@ -631,7 +634,7 @@ function Admin:freezePlayer ( )
 end
 
 function Admin:killPlayer ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		Network:Send ( "admin.executeAction", { "player.kill", player } )
 	else
@@ -640,9 +643,9 @@ function Admin:killPlayer ( )
 end
 
 function Admin:setHealth ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		local value = tonumber ( self.panel.valueField:GetText ( ) ) or 0
+		local value = tonumber ( self.panel.main.valueField:GetText ( ) ) or 0
 		if ( value > 100 ) then
 			value = 100
 		end
@@ -653,9 +656,9 @@ function Admin:setHealth ( )
 end
 
 function Admin:setModel ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		local value = tonumber ( self.panel.valueField:GetText ( ) ) or 0
+		local value = tonumber ( self.panel.main.valueField:GetText ( ) ) or 0
 		Network:Send ( "admin.executeAction", { "player.setmodel", player, value } )
 	else
 		self:Message ( "No player selected.", "err" )
@@ -663,9 +666,9 @@ function Admin:setModel ( )
 end
 
 function Admin:setMoney ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		local value = tonumber ( self.panel.valueField:GetText ( ) ) or 0
+		local value = tonumber ( self.panel.main.valueField:GetText ( ) ) or 0
 		Network:Send ( "admin.executeAction", { "player.setmoney", player, value } )
 	else
 		self:Message ( "No player selected.", "err" )
@@ -673,9 +676,9 @@ function Admin:setMoney ( )
 end
 
 function Admin:giveMoney ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		local value = tonumber ( self.panel.valueField:GetText ( ) ) or 0
+		local value = tonumber ( self.panel.main.valueField:GetText ( ) ) or 0
 		Network:Send ( "admin.executeAction", { "player.givemoney", player, value } )
 	else
 		self:Message ( "No player selected.", "err" )
@@ -683,7 +686,7 @@ function Admin:giveMoney ( )
 end
 
 function Admin:warpTo ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		Network:Send ( "admin.executeAction", { "player.warp", player } )
 	else
@@ -692,16 +695,16 @@ function Admin:warpTo ( )
 end
 
 function Admin:showWarpWindow ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		self.victim = player
-		self.warpPanel.window:SetVisible ( true )
-		self.warpPanel.list:Clear ( )
-		local item = self.warpPanel.list:AddItem ( LocalPlayer:GetName ( ) )
+		self.panel.warp.window:SetVisible ( true )
+		self.panel.warp.list:Clear ( )
+		local item = self.panel.warp.list:AddItem ( LocalPlayer:GetName ( ) )
 		item:SetDataObject ( "id", LocalPlayer )
 		self.warpPlayers [ LocalPlayer:GetSteamId ( ) ] = item
 		for player in Client:GetPlayers ( ) do
-			local item = self.warpPanel.list:AddItem ( player:GetName ( ) )
+			local item = self.panel.warp.list:AddItem ( player:GetName ( ) )
 			item:SetDataObject ( "id", player )
 			self.warpPlayers [ player:GetSteamId ( ) ] = item
 		end
@@ -712,10 +715,10 @@ end
 
 function Admin:warpPlayerTo ( )
 	if IsValid ( self.victim, false ) then
-		local player = self:getListSelectedPlayer ( self.warpPanel.list )
+		local player = self:getListSelectedPlayer ( self.panel.warp.list )
 		if ( player ) then
 			Network:Send ( "admin.executeAction", { "player.warpto", self.victim, player } )
-			self.warpPanel.window:SetVisible ( false )
+			self.panel.warp.window:SetVisible ( false )
 		else
 			self:Message ( "Player selected is offline.", "err" )
 		end
@@ -725,7 +728,7 @@ function Admin:warpPlayerTo ( )
 end
 
 function Admin:searchWarpPlayer ( )
-	local text = self.warpPanel.search:GetText ( ):lower ( )
+	local text = self.panel.warp.search:GetText ( ):lower ( )
 	if ( text:len ( ) > 0 ) then
 		for _, item in pairs ( self.warpPlayers ) do
 			item:SetVisible ( false )
@@ -741,7 +744,7 @@ function Admin:searchWarpPlayer ( )
 end
 
 function Admin:spectate ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		self.victim = player
 		if ( not spectateEvent ) then
@@ -776,14 +779,14 @@ function Admin:displayVehicleTemplates ( )
 		end
 		table.remove ( self.templateItems, index )
 	end
-	local name = self.panel.vehicleMenu:GetSelectedItem ( ):GetText ( )
+	local name = self.panel.main.vehicleMenu:GetSelectedItem ( ):GetText ( )
 	if ( name ) then
 		local model = self.vehicleModelFromName [ name ]
 		if ( model ) then
 			local templates = vehicleTemplates [ model ]
 			if ( templates ) then
 				for _, template in ipairs ( templates ) do
-					table.insert ( self.templateItems, self.panel.vehicleTemplateMenu:AddItem ( tostring ( template ) ) )
+					table.insert ( self.templateItems, self.panel.main.vehicleTemplateMenu:AddItem ( tostring ( template ) ) )
 				end
 			end
 		end
@@ -791,13 +794,13 @@ function Admin:displayVehicleTemplates ( )
 end
 
 function Admin:giveVehicle ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		local name = self.panel.vehicleMenu:GetSelectedItem ( ):GetText ( )
+		local name = self.panel.main.vehicleMenu:GetSelectedItem ( ):GetText ( )
 		if ( name ) then
 			local model = self.vehicleModelFromName [ name ]
 			if ( model ) then
-				local template = self.panel.vehicleTemplateMenu:GetSelectedItem ( ):GetText ( )
+				local template = self.panel.main.vehicleTemplateMenu:GetSelectedItem ( ):GetText ( )
 				Network:Send ( "admin.executeAction", { "player.givevehicle", player, model, template } )
 			end
 		end
@@ -807,7 +810,7 @@ function Admin:giveVehicle ( )
 end
 
 function Admin:destroyVehicle ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		Network:Send ( "admin.executeAction", { "player.destroyvehicle", player } )
 	else
@@ -816,7 +819,7 @@ function Admin:destroyVehicle ( )
 end
 
 function Admin:repairVehicle ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		Network:Send ( "admin.executeAction", { "player.repairvehicle", player } )
 	else
@@ -825,10 +828,10 @@ function Admin:repairVehicle ( )
 end
 
 function Admin:showVehicleColourSelector ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		if player:InVehicle ( ) then
-			self.vehColorPanel.window:SetVisible ( true )
+			self.panel.vehColor.window:SetVisible ( true )
 			self.victim = player
 		else
 			self:Message ( "This player is not in a vehicle.", "err" )
@@ -841,9 +844,9 @@ end
 function Admin:setVehicleTone1Colour ( )
 	if IsValid ( self.victim, false ) then
 		if self.victim:InVehicle ( ) then
-			local color = self.vehColorPanel.tone1:GetColor ( )
+			local color = self.panel.vehColor.tone1:GetColor ( )
 			Network:Send ( "admin.executeAction", { "player.setvehiclecolour", self.victim, "tone1", color } )
-			self.vehColorPanel.window:SetVisible ( false )
+			self.panel.vehColor.window:SetVisible ( false )
 			self.victim = nil
 		else
 			self:Message ( "This player is not in a vehicle.", "err" )
@@ -856,9 +859,9 @@ end
 function Admin:setVehicleTone2Colour ( )
 	if IsValid ( self.victim, false ) then
 		if self.victim:InVehicle ( ) then
-			local color = self.vehColorPanel.tone2:GetColor ( )
+			local color = self.panel.vehColor.tone2:GetColor ( )
 			Network:Send ( "admin.executeAction", { "player.setvehiclecolour", self.victim, "tone2", color } )
-			self.vehColorPanel.window:SetVisible ( false )
+			self.panel.vehColor.window:SetVisible ( false )
 			self.victim = nil
 		else
 			self:Message ( "This player is not in a vehicle.", "err" )
@@ -869,10 +872,10 @@ function Admin:setVehicleTone2Colour ( )
 end
 
 function Admin:giveWeapon ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		local name = self.panel.weaponMenu:GetSelectedItem ( ):GetText ( )
-		local slot = self.panel.weaponSlotMenu:GetSelectedItem ( ):GetText ( )
+		local name = self.panel.main.weaponMenu:GetSelectedItem ( ):GetText ( )
+		local slot = self.panel.main.weaponSlotMenu:GetSelectedItem ( ):GetText ( )
 		if ( name and slot ) then
 			Network:Send ( "admin.executeAction", { "player.giveweapon", player, getWeaponIDFromName ( name ), slot } )
 		end
@@ -882,9 +885,9 @@ function Admin:giveWeapon ( )
 end
 
 function Admin:giveAdmin ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
-		if ( self.panel.giveAdmin:GetText ( ) == "Give admin rights" ) then
+		if ( self.panel.main.giveAdmin:GetText ( ) == "Give admin rights" ) then
 			Network:Send ( "admin.executeAction", { "player.giveadmin", player } )
 		else
 			Network:Send ( "admin.executeAction", { "player.takeadmin", player } )
@@ -895,10 +898,10 @@ function Admin:giveAdmin ( )
 end
 
 function Admin:showShoutWindow ( )
-	local player = self:getListSelectedPlayer ( self.panel.playersList )
+	local player = self:getListSelectedPlayer ( self.panel.main.playersList )
 	if ( player ) then
 		self.victim = player
-		self.shoutPanel.window:SetVisible ( true )
+		self.panel.shout.window:SetVisible ( true )
 	else
 		self:Message ( "No player selected.", "err" )	
 	end
@@ -906,11 +909,11 @@ end
 
 function Admin:shoutPlayer ( )
 	if IsValid ( self.victim, false ) then
-		local message = self.shoutPanel.message:GetText ( )
+		local message = self.panel.shout.message:GetText ( )
 		if ( message ~= "" ) then
 			Network:Send ( "admin.executeAction", { "player.shout", self.victim, message } )
 			self.victim = false
-			self.shoutPanel.window:SetVisible ( false )
+			self.panel.shout.window:SetVisible ( false )
 		end
 	else
 		self:Message ( "Player is offline.", "err" )	
@@ -949,12 +952,12 @@ function Admin:removeShout ( )
 end
 
 function Admin:displayBans ( bans )
-	self.panel.bansList:Clear ( )
+	self.panel.main.bansList:Clear ( )
 	self.bans = { }
 	self.banData = { }
 	if ( bans ) then
 		for _, ban in ipairs ( bans ) do
-			local item = self.panel.bansList:AddItem ( ( ban.name == "" and ban.steamID or ban.name .."(".. tostring ( ban.steamID ) ..")" ) )
+			local item = self.panel.main.bansList:AddItem ( ( ban.name == "" and ban.steamID or ban.name .."(".. tostring ( ban.steamID ) ..")" ) )
 			item:SetDataString ( "id", ban.steamID )
 			self.banData [ ban.steamID ] = ban
 			self.bans [ ban.steamID ] = item
@@ -963,20 +966,20 @@ function Admin:displayBans ( bans )
 end
 
 function Admin:getBanInformation ( )
-	local row = self.panel.bansList:GetSelectedRow ( )
+	local row = self.panel.main.bansList:GetSelectedRow ( )
 	if ( row ) then
 		local id = row:GetDataString ( "id" )
 		if ( id ) then
 			local data = self.banData [ id ]
 			if ( data ) then
-				self.panel.banSteamID:SetText ( "Steam ID: ".. tostring ( id ) )
-				self.panel.banName:SetText ( "Name: ".. tostring ( data.name ) )
+				self.panel.main.banSteamID:SetText ( "Steam ID: ".. tostring ( id ) )
+				self.panel.main.banName:SetText ( "Name: ".. tostring ( data.name ) )
 				local duration = tonumber ( data.duration ) or 0
 				local expired = false
 				if ( duration <= self.serverInfo.time and duration ~= 0 ) then
-					self.panel.banDuration:SetText ( "Duration: Already expired." )
+					self.panel.main.banDuration:SetText ( "Duration: Already expired." )
 				elseif ( duration == 0 ) then
-					self.panel.banDuration:SetText ( "Duration: Permanent." )
+					self.panel.main.banDuration:SetText ( "Duration: Permanent." )
 				else
 					local timeLeft = ( duration - self.serverInfo.time )
 					local minutes = math.floor ( timeLeft / 60 )
@@ -985,20 +988,20 @@ function Admin:getBanInformation ( )
 					local minutes = ( minutes - ( hours * 60 ) )
 					local days = math.floor ( hours / 24 )
 					local hours = ( hours - ( days * 24 ) )
-					self.panel.banDuration:SetText ( "Duration: ".. tostring ( days ) .." day(s), ".. tostring ( hours ) .." hour(s), ".. tostring ( minutes ) .." min(s), ".. tostring ( seconds ) .." sec(s)" )
+					self.panel.main.banDuration:SetText ( "Duration: ".. tostring ( days ) .." day(s), ".. tostring ( hours ) .." hour(s), ".. tostring ( minutes ) .." min(s), ".. tostring ( seconds ) .." sec(s)" )
 				end
-				self.panel.banDuration:SizeToContents ( )
-				self.panel.banDate:SetText ( "Date: ".. tostring ( data.date ):gsub ( " ", " - " ) )
-				self.panel.banReason:SetText ( "Reason: ".. tostring ( data.reason ) )
-				self.panel.banResponsible:SetText ( "Responsible: ".. tostring ( data.responsible ) )
-				self.panel.banResponsibleSteam:SetText ( "Responsible Steam ID: ".. tostring ( data.responsibleSteamID ) )
+				self.panel.main.banDuration:SizeToContents ( )
+				self.panel.main.banDate:SetText ( "Date: ".. tostring ( data.date ):gsub ( " ", " - " ) )
+				self.panel.main.banReason:SetText ( "Reason: ".. tostring ( data.reason ) )
+				self.panel.main.banResponsible:SetText ( "Responsible: ".. tostring ( data.responsible ) )
+				self.panel.main.banResponsibleSteam:SetText ( "Responsible Steam ID: ".. tostring ( data.responsibleSteamID ) )
 			end
 		end
 	end
 end
 
 function Admin:searchBan ( )
-	local text = self.panel.bansSearch:GetText ( ):lower ( )
+	local text = self.panel.main.bansSearch:GetText ( ):lower ( )
 	if ( text:len ( ) > 0 ) then
 		for _, item in pairs ( self.bans ) do
 			item:SetVisible ( false )
@@ -1018,7 +1021,7 @@ function Admin:refreshBans ( )
 end
 
 function Admin:removeBan ( )
-	local row = self.panel.bansList:GetSelectedRow ( )
+	local row = self.panel.main.bansList:GetSelectedRow ( )
 	if ( row ) then
 		local id = row:GetDataString ( "id" )
 		if ( id ) then
@@ -1030,15 +1033,15 @@ function Admin:removeBan ( )
 end
 
 function Admin:showManualBanWindow ( )
-	self.manualBanPanel.window:SetVisible ( true )
+	self.panel.manualBan.window:SetVisible ( true )
 end
 
 function Admin:manualBan ( )
-	local steamID = self.manualBanPanel.steamID:GetText ( )
+	local steamID = self.panel.manualBan.steamID:GetText ( )
 	if ( steamID ~= "" ) then
-		local reason = ( self.manualBanPanel.reasonCheck:GetChecked ( ) == true and self.manualBanPanel.reasonEdit:GetText ( ) or self.manualBanPanel.reasonsBox:GetSelectedItem ( ):GetText ( ) )
-		local durationMethod = self.manualBanPanel.durationBox:GetSelectedItem ( ):GetText ( )
-		local duration = tonumber ( self.manualBanPanel.duration:GetText ( ) )
+		local reason = ( self.panel.manualBan.reasonCheck:GetChecked ( ) == true and self.panel.manualBan.reasonEdit:GetText ( ) or self.panel.manualBan.reasonsBox:GetSelectedItem ( ):GetText ( ) )
+		local durationMethod = self.panel.manualBan.durationBox:GetSelectedItem ( ):GetText ( )
+		local duration = tonumber ( self.panel.manualBan.duration:GetText ( ) )
 		if ( not duration or duration < 0 or durationMethod == "Permanent" ) then
 			duration = 0
 		end
@@ -1051,29 +1054,29 @@ function Admin:manualBan ( )
 		end
 
 		Network:Send ( "admin.executeAction", { "ban.add", steamID, reason, duration } )
-		self.manualBanPanel.window:SetVisible ( false )
+		self.panel.manualBan.window:SetVisible ( false )
 	else
 		self:Message ( "No steam ID given.", "err" )
 	end
 end
 
 function Admin:setTime ( )
-	local value = self.panel.serverGameTimeField:GetText ( )
+	local value = self.panel.main.serverGameTimeField:GetText ( )
 	Network:Send ( "admin.executeAction", { "general.settime", value } )
 end
 
 function Admin:setWeather ( )
-	local value = self.panel.serverWeatherField:GetText ( )
+	local value = self.panel.main.serverWeatherField:GetText ( )
 	Network:Send ( "admin.executeAction", { "general.setweather", value } )
 end
 
 function Admin:setTimeStep ( )
-	local value = self.panel.serverTimeStepField:GetText ( )
+	local value = self.panel.main.serverTimeStepField:GetText ( )
 	Network:Send ( "admin.executeAction", { "general.settimestep", value } )
 end
 
 function Admin:sendChatMessage ( )
-	local text = self.panel.chatMessage:GetText ( )
+	local text = self.panel.main.chatMessage:GetText ( )
 	if ( text ~= "" ) then
 		Network:Send ( "admin.executeAction", { "general.tab_adminchat", text } )
 		self:clearChatMessage ( )
@@ -1081,29 +1084,29 @@ function Admin:sendChatMessage ( )
 end
 
 function Admin:clearChatMessage ( )
-	self.panel.chatMessage:SetText ( "" )
+	self.panel.main.chatMessage:SetText ( "" )
 end
 
 function Admin:addChatMessage ( args )
-	local text = self.panel.chatMessages:GetText ( )
+	local text = self.panel.main.chatMessages:GetText ( )
 	if ( text == "" ) then
-		self.panel.chatMessages:SetText ( args.msg )
+		self.panel.main.chatMessages:SetText ( args.msg )
 	else
-		self.panel.chatMessages:SetText ( text .."\n".. args.msg )
+		self.panel.main.chatMessages:SetText ( text .."\n".. args.msg )
 	end
-	self.panel.chatMessages:SizeToContents ( )
+	self.panel.main.chatMessages:SizeToContents ( )
 end
 
 function Admin:displayACL ( acl )
 	if ( type ( acl ) == "table" ) then
 		self.aclGroupData = { }
-		self.panel.aclTree:Clear ( )
-		self.aclObjectPanel.window:SetDataString ( "group", "" )
-		self.panel.aclTree:SetDataString ( "group", "" )
-		self.panel.aclTree:SetDataString ( "object", "" )
+		self.panel.main.aclTree:Clear ( )
+		self.panel.aclObject.window:SetDataString ( "group", "" )
+		self.panel.main.aclTree:SetDataString ( "group", "" )
+		self.panel.main.aclTree:SetDataString ( "object", "" )
 		for _, group in ipairs ( acl ) do
 			self.aclGroupData [ group.name ] = group
-			local node = self.panel.aclTree:AddNode ( tostring ( group.name ) )
+			local node = self.panel.main.aclTree:AddNode ( tostring ( group.name ) )
 			node:Subscribe ( "Select", self, self.onACLGroupClick )
 			local permNode = node:AddNode ( "Permissions" )
 			for _, perm in ipairs ( self.permissionNames ) do
@@ -1126,45 +1129,45 @@ function Admin:onACLGroupClick ( node )
 	local name = node:GetText ( )
 	local data = self.aclGroupData [ name ]
 	if ( type ( data ) == "table" ) then
-		self.panel.aclDataLabel:SetText ( "Group name: ".. tostring ( name ) .."\n\nCreator: ".. tostring ( data.creator ) .."\n\nCreation date: ".. tostring ( data.creationDate ):gsub ( " ", " - " ) .."\n\nGroup objects: ".. tostring ( #data.objects ) )
-		self.panel.aclDataLabel:SizeToContents ( )
-		self.panel.aclTree:SetDataString ( "group", name )
+		self.panel.main.aclDataLabel:SetText ( "Group name: ".. tostring ( name ) .."\n\nCreator: ".. tostring ( data.creator ) .."\n\nCreation date: ".. tostring ( data.creationDate ):gsub ( " ", " - " ) .."\n\nGroup objects: ".. tostring ( #data.objects ) )
+		self.panel.main.aclDataLabel:SizeToContents ( )
+		self.panel.main.aclTree:SetDataString ( "group", name )
 	end
 end
 
 function Admin:onACLRightClick ( node )
 	local perm = node:GetText ( )
 	local value = node:GetDataString ( "value" )
-	self.permPanelChange.window:SetVisible ( true )
-	self.permPanelChange.label:SetText ( "Permission: ".. tostring ( perm ) )
-	self.permPanelChange.label:SizeToContents ( )
-	self.permPanelChange.value:SetText ( tostring ( value ) )
+	self.panel.permChange.window:SetVisible ( true )
+	self.panel.permChange.label:SetText ( "Permission: ".. tostring ( perm ) )
+	self.panel.permChange.label:SizeToContents ( )
+	self.panel.permChange.value:SetText ( tostring ( value ) )
 end
 
 function Admin:modifyACLPermission ( )
-	local value = self.permPanelChange.value:GetText ( )
-	local perm = self.permPanelChange.label:GetText ( ):gsub ( "Permission: ", "" )
-	local group = self.panel.aclTree:GetDataString ( "group" )
+	local value = self.panel.permChange.value:GetText ( )
+	local perm = self.panel.permChange.label:GetText ( ):gsub ( "Permission: ", "" )
+	local group = self.panel.main.aclTree:GetDataString ( "group" )
 	if ( value == "true" or value == "false" ) then
 		Network:Send ( "admin.executeAction", { "acl.modifypermission", group, perm, value } )
 	else
 		self:Message ( "Invalid value, accepted values: true/false.", "err" )
 	end
-	self.permPanelChange.window:SetVisible ( false )
+	self.panel.permChange.window:SetVisible ( false )
 end
 
 function Admin:showACLCreateWindow ( )
-	self.aclCreatePanel.permissions:Clear ( )
+	self.panel.aclCreate.permissions:Clear ( )
 	self.permissionItems = { }
 	for _, perm in ipairs ( self.permissionNames ) do
-		self.permissionItems [ perm ] = self.aclCreatePanel.permissions:AddItem ( tostring ( perm ) )
+		self.permissionItems [ perm ] = self.panel.aclCreate.permissions:AddItem ( tostring ( perm ) )
 		self.permissionSelected [ perm ] = false
 	end
-	self.aclCreatePanel.window:SetVisible ( true )
+	self.panel.aclCreate.window:SetVisible ( true )
 end
 
 function Admin:onPermissionSelect ( )
-	local item = self.aclCreatePanel.permissions:GetSelectedRow ( )
+	local item = self.panel.aclCreate.permissions:GetSelectedRow ( )
 	if ( item ) then
 		local name = item:GetCellText ( 0 )
 		if ( not self.permissionSelected [ name ] ) then
@@ -1185,42 +1188,42 @@ function Admin:onPermissionSelectAll ( )
 end
 
 function Admin:createACLGroup ( )
-	local name = self.aclCreatePanel.name:GetText ( )
+	local name = self.panel.aclCreate.name:GetText ( )
 	if ( name ~= "" ) then
 		local perms = { }
 		for _, perm in ipairs ( self.permissionNames ) do
 			perms [ perm ] = self.permissionSelected [ perm ]
 		end
 		Network:Send ( "admin.executeAction", { "acl.creategroup", name, perms } )
-		self.aclCreatePanel.window:SetVisible ( false )
+		self.panel.aclCreate.window:SetVisible ( false )
 	else
 		self:Message ( "Write a group name.", "err" )
 	end
 end
 
 function Admin:destroyACLGroup ( )
-	local group = self.panel.aclTree:GetDataString ( "group" )
+	local group = self.panel.main.aclTree:GetDataString ( "group" )
 	if ( group and group ~= "" ) then
 		Network:Send ( "admin.executeAction", { "acl.removegroup", group } )
 	end
 end
 
 function Admin:showACLAddObjectWindow ( )
-	local group = self.panel.aclTree:GetDataString ( "group" )
+	local group = self.panel.main.aclTree:GetDataString ( "group" )
 	if ( group and group ~= "" ) then
-		self.aclObjectPanel.window:SetTitle ( "Add Object to: ".. tostring ( group ) )
-		self.aclObjectPanel.window:SetDataString ( "group", group )
-		self.aclObjectPanel.window:SetVisible ( true )
+		self.panel.aclObject.window:SetTitle ( "Add Object to: ".. tostring ( group ) )
+		self.panel.aclObject.window:SetDataString ( "group", group )
+		self.panel.aclObject.window:SetVisible ( true )
 	end
 end
 
 function Admin:addACLObject ( )
-	local group = self.aclObjectPanel.window:GetDataString ( "group" )
+	local group = self.panel.aclObject.window:GetDataString ( "group" )
 	if ( group and group ~= "" ) then
-		local steamID = self.aclObjectPanel.value:GetText ( )
+		local steamID = self.panel.aclObject.value:GetText ( )
 		if ( steamID ~= "" ) then
 			Network:Send ( "admin.executeAction", { "acl.addobject", group, steamID } )
-			self.aclObjectPanel.window:SetVisible ( false )
+			self.panel.aclObject.window:SetVisible ( false )
 		else
 			self:Message ( "Write a steam ID to add.", "err" )
 		end
@@ -1230,14 +1233,14 @@ end
 function Admin:onACLObjectClick ( node )
 	local steamID = node:GetText ( )
 	if ( steamID ) then
-		self.panel.aclTree:SetDataString ( "object", steamID )
+		self.panel.main.aclTree:SetDataString ( "object", steamID )
 	end
 end
 
 function Admin:removeACLObject ( )
-	local group = self.panel.aclTree:GetDataString ( "group" )
+	local group = self.panel.main.aclTree:GetDataString ( "group" )
 	if ( group and group ~= "" ) then
-		local object = self.panel.aclTree:GetDataString ( "object" )
+		local object = self.panel.main.aclTree:GetDataString ( "object" )
 		if ( object and object ~= "" ) then
 			Network:Send ( "admin.executeAction", { "acl.removeobject", group, object } )
 		end
@@ -1245,30 +1248,30 @@ function Admin:removeACLObject ( )
 end
 
 function Admin:displayModules ( modules )
-	self.panel.modulesList:Clear ( )
+	self.panel.main.modulesList:Clear ( )
 	self.modules = { }
 	if ( modules ) then
 		for name, state in pairs ( modules [ 1 ] ) do
-			local item = self.panel.modulesList:AddItem ( tostring ( name ) )
+			local item = self.panel.main.modulesList:AddItem ( tostring ( name ) )
 			item:SetTextColor ( ( state and Color ( 0, 255, 0 ) or Color ( 255, 0, 0 ) ) )
 			self.modules [ name ] = item
 		end
 
-		self.panel.modulesLog:SetText ( "" )
+		self.panel.main.modulesLog:SetText ( "" )
 		for index, log_ in ipairs ( modules [ 2 ] ) do
 			if ( index == 1 ) then
-				self.panel.modulesLog:SetText ( modules [ 2 ] [ 1 ] )
+				self.panel.main.modulesLog:SetText ( modules [ 2 ] [ 1 ] )
 			else
-				self.panel.modulesLog:SetText ( self.panel.modulesLog:GetText ( ) .."\n".. tostring ( log_ ) )
+				self.panel.main.modulesLog:SetText ( self.panel.main.modulesLog:GetText ( ) .."\n".. tostring ( log_ ) )
 			end
 		end
-		self.panel.modulesLog:SizeToContents ( )
-		self.panel.modulesLog:SetWrap ( true )
+		self.panel.main.modulesLog:SizeToContents ( )
+		self.panel.main.modulesLog:SetWrap ( true )
 	end
 end
 
 function Admin:searchModule ( )
-	local text = self.panel.modulesSearch:GetText ( ):lower ( )
+	local text = self.panel.main.modulesSearch:GetText ( ):lower ( )
 	if ( text:len ( ) > 0 ) then
 		for _, item in pairs ( self.modules ) do
 			item:SetVisible ( false )
@@ -1284,7 +1287,7 @@ function Admin:searchModule ( )
 end
 
 function Admin:loadModule ( )
-	local row = self.panel.modulesList:GetSelectedRow ( )
+	local row = self.panel.main.modulesList:GetSelectedRow ( )
 	if ( row ) then
 		local name = row:GetCellText ( 0 )
 		if ( name ) then
@@ -1296,7 +1299,7 @@ function Admin:loadModule ( )
 end
 
 function Admin:reloadModule ( )
-	local row = self.panel.modulesList:GetSelectedRow ( )
+	local row = self.panel.main.modulesList:GetSelectedRow ( )
 	if ( row ) then
 		local name = row:GetCellText ( 0 )
 		if ( name ) then
@@ -1308,7 +1311,7 @@ function Admin:reloadModule ( )
 end
 
 function Admin:unloadModule ( )
-	local row = self.panel.modulesList:GetSelectedRow ( )
+	local row = self.panel.main.modulesList:GetSelectedRow ( )
 	if ( row ) then
 		local name = row:GetCellText ( 0 )
 		if ( name ) then
@@ -1344,6 +1347,15 @@ function Admin:getListSelectedPlayer ( list )
 		end
 	else
 		return false
+	end
+end
+
+function Admin:onModuleUnload ( )
+	for _, panel in pairs ( self.panel ) do
+		for _, gwen in pairs ( panel ) do
+			gwen:Remove ( )
+			gwen = nil
+		end
 	end
 end
 


### PR DESCRIPTION
Split GWEN objects into multiple tables within the self.panel table and added a function to manually remove each object on module unload.

Not sure if this fixes the issue completely, but it seemed to improve stability in some tests.
